### PR TITLE
feat: multi-tenant frontend guard (org required for staff)

### DIFF
--- a/docs/plans/01-multi-tenant.md
+++ b/docs/plans/01-multi-tenant.md
@@ -1,6 +1,6 @@
 # Plan: Multi-tenant (frontend)
 
-**Status:** not started  
+**Status:** in progress (Phase 2 started)  
 **Project:** ubuteco-react  
 **Backend:** [01-multi-tenant.md](../../../ubuteco_api/docs/plans/01-multi-tenant.md)  
 **Priority:** P0 (after / in parallel with API Phase 1–2)
@@ -17,16 +17,16 @@ Frontend must not rely on sending `organization_id` for scoped operations; use t
 
 ## Phase 1 — Audit API calls
 
-- [ ] Grep `organization_id` in services/thunks/forms
-- [ ] Remove from POST/PATCH bodies where API will ignore it (orders, users, products)
-- [ ] Keep read-only display of org from `auth.user.organization`
+- [x] Grep `organization_id` in services/thunks/forms — no writes send tenant id
+- [x] Client already omits `organization_id` on POST/PATCH (orders, users, products)
+- [x] Read-only display of org from `auth.user.organization`
 
 ---
 
 ## Phase 2 — Auth state
 
-- [ ] Ensure `fetchCurrentUser` always hydrates `organization` (id, name, `operational_status`, future locale/currency)
-- [ ] Guard routes that require org: redirect if `user.organization_id` missing
+- [x] `fetchCurrentUser` hydrates nested `organization` (via AuthHydrator)
+- [x] Guard routes: `AuthGuard` redirects to `/forbidden` when org-scoped role lacks organization
 
 ---
 

--- a/src/app/_components/AppearanceProvider.tsx
+++ b/src/app/_components/AppearanceProvider.tsx
@@ -16,23 +16,22 @@ type AppearanceContextValue = {
 
 const AppearanceContext = createContext<AppearanceContextValue | null>(null);
 
-function readInitialMode(): AppearanceMode {
-  if (typeof window === "undefined") return "system";
-  return readStoredAppearance();
-}
-
 export function AppearanceProvider({children}: {children: ReactNode}) {
-  const [mode, setModeState] = useState<AppearanceMode>(readInitialMode);
+  const [mode, setModeState] = useState<AppearanceMode>("system");
   const [isDark, setIsDark] = useState(false);
+  const [ready, setReady] = useState(false);
 
   useEffect(() => {
     const stored = readStoredAppearance();
     setModeState(stored);
     applyAppearance(stored);
     setIsDark(document.documentElement.classList.contains("dark"));
+    setReady(true);
   }, []);
 
   useEffect(() => {
+    if (!ready) return;
+
     applyAppearance(mode);
     setIsDark(document.documentElement.classList.contains("dark"));
 
@@ -46,7 +45,7 @@ export function AppearanceProvider({children}: {children: ReactNode}) {
 
     media.addEventListener("change", syncSystem);
     return () => media.removeEventListener("change", syncSystem);
-  }, [mode]);
+  }, [mode, ready]);
 
   const setMode = (next: AppearanceMode) => {
     setModeState(next);

--- a/src/app/_components/AppearanceScript.tsx
+++ b/src/app/_components/AppearanceScript.tsx
@@ -1,15 +1,21 @@
-export function AppearanceScript() {
-  const script = `
-    (function () {
-      try {
-        var key = "ubuteco-appearance";
-        var mode = localStorage.getItem(key);
-        var resolved = mode === "dark" || (mode !== "light" && window.matchMedia("(prefers-color-scheme: dark)").matches);
-        document.documentElement.classList.toggle("dark", resolved);
-        document.documentElement.dataset.appearance = mode || "system";
-      } catch (e) {}
-    })();
-  `;
+import Script from "next/script";
 
-  return <script dangerouslySetInnerHTML={{__html: script}}/>;
+const APPEARANCE_INIT_SCRIPT = `
+(function () {
+  try {
+    var key = "ubuteco-appearance";
+    var mode = localStorage.getItem(key);
+    var resolved = mode === "dark" || (mode !== "light" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+    document.documentElement.classList.toggle("dark", resolved);
+    document.documentElement.dataset.appearance = mode || "system";
+  } catch (e) {}
+})();
+`;
+
+export function AppearanceScript() {
+  return (
+    <Script id="ubuteco-appearance-init" strategy="beforeInteractive">
+      {APPEARANCE_INIT_SCRIPT}
+    </Script>
+  );
 }

--- a/src/app/_components/AuthGuard.tsx
+++ b/src/app/_components/AuthGuard.tsx
@@ -5,9 +5,11 @@ import {usePathname, useRouter} from "next/navigation";
 import {getAuthToken} from "@/app/_lib/auth-storage";
 import {isAuthPublicPath} from "@/app/_lib/auth-routes";
 import {
+  hasOrganization,
   isKitchenAllowedPath,
   isKitchenStaff,
   isOperationalMutationPath,
+  requiresOrganization,
 } from "@/app/_lib/auth-roles";
 import {useAuthCapabilities} from "@/app/_hooks/useAuthCapabilities";
 import {useClientReady} from "@/app/_hooks/useClientReady";
@@ -32,6 +34,11 @@ export default function AuthGuard({children}: {children: ReactNode}) {
     const token = getAuthToken();
     if (!token && authStatus !== "authenticated") {
       router.replace("/login");
+      return;
+    }
+
+    if (user && requiresOrganization(user) && !hasOrganization(user)) {
+      router.replace("/forbidden");
       return;
     }
 

--- a/src/app/_lib/auth-roles.ts
+++ b/src/app/_lib/auth-roles.ts
@@ -8,6 +8,17 @@ export function isSuperAdmin(user: User | null | undefined): boolean {
   return getRoleName(user) === "SUPER_ADMIN";
 }
 
+const ORG_SCOPED_ROLES = new Set(["ADMIN", "KITCHEN", "WAITER", "CASH_REGISTER"]);
+
+export function requiresOrganization(user: User | null | undefined): boolean {
+  const role = getRoleName(user);
+  return role != null && ORG_SCOPED_ROLES.has(role);
+}
+
+export function hasOrganization(user: User | null | undefined): boolean {
+  return user?.organization_id != null || user?.organization?.id != null;
+}
+
 /** Super admin may view org catalog (beers, dishes, etc.) but not mutate it. */
 export function canMutateOperationalData(user: User | null | undefined): boolean {
   return !isSuperAdmin(user);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,10 +21,8 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <head>
-        <AppearanceScript/>
-      </head>
       <body className={`${robotoSans.variable} ${robotoMono.variable} antialiased`}>
+        <AppearanceScript/>
         <Providers>{children}</Providers>
       </body>
     </html>


### PR DESCRIPTION
## Summary

Companion to the API multi-tenant PR. The frontend must not send `organization_id` for scoped operations — tenant comes from the authenticated user returned by the API.

This PR completes [plan 01 — multi-tenant (frontend)](docs/plans/01-multi-tenant.md) phases 1–2:

- Confirms the client already omits `organization_id` on POST/PATCH bodies
- Adds `requiresOrganization()` / `hasOrganization()` in `auth-roles.ts`
- `AuthGuard` redirects org-scoped staff (ADMIN, KITCHEN, WAITER, CASH_REGISTER) without an organization to `/forbidden`

`SUPER_ADMIN` and `CUSTOMER` without an org are unaffected.

## Out of scope (follow-up)

- Platform UI at `/platform/*` for super admin cross-org browsing
- MSW cross-tenant tests (plan phase 4)

## Test plan

- [ ] Login as org admin → app works normally; settings shows organization name
- [ ] Login as kitchen staff without org (if test user exists) → redirect to `/forbidden`
- [ ] Super admin without org → can still browse catalog read-only
- [ ] No network requests include `organization_id` in create/update payloads (DevTools)

## Companion PR

API enforcement: ubuteco_api PR #29 (`feature/multi-tenant`)