### PR TITLE
feat: user dark mode (Light / Dark / System)

### DIFF
--- a/docs/plans/06-organizations-ui.md
+++ b/docs/plans/06-organizations-ui.md
@@ -18,7 +18,7 @@ Replace the **placeholder** `/organizations` page with a real admin experience: 
 
 - `src/app/organizations/page.tsx` — placeholder (`<h1>Tables index page</h1>` — copy-paste error).
 - Sidebar links “Organizations” for privileged roles.
-- API: `OrganizationsController`, themes nested resource, `operational_status` on org.
+- API: `OrganizationsController`, `operational_status` on org.
 - Kitchen page already PATCHes `operational_status` for open/closed kitchen.
 
 ---
@@ -34,9 +34,8 @@ Replace the **placeholder** `/organizations` page with a real admin experience: 
 
 ## Phase 2 — Organization profile UI
 
-- [ ] Show: name, phone, logo, `operational_status`, theme summary
+- [ ] Show: name, phone, logo, `operational_status`
 - [ ] Edit form: name, phone, logo upload (match API multipart patterns from dishes/beers)
-- [ ] Link to theme colors or inline theme section (API: `organizations/themes`)
 
 ---
 

--- a/docs/plans/12-appearance-dark-mode.md
+++ b/docs/plans/12-appearance-dark-mode.md
@@ -1,0 +1,78 @@
+# Plan: Appearance — dark mode (user preference)
+
+**Status:** in progress  
+**Project:** ubuteco-react (primary) + ubuteco_api (legacy removal)  
+**Priority:** P2  
+**Estimated effort:** 0.5 sprint
+
+---
+
+## Goal
+
+Replace the abandoned **per-org theme customizer** (Angular-era header/sidebar/footer colors) with a **user-level dark mode**: Light, Dark, or System.
+
+Org branding stays via **logo + name** on Organizations UI (plan 06), not sidebar colors.
+
+---
+
+## Decision (approved)
+
+| Approach | Verdict |
+|----------|---------|
+| Per-org color presets (`Theme` model) | **Removed** — dead API, never used in React |
+| RTL per org | **Removed** — never persisted correctly |
+| User dark mode (localStorage) | **Ship** |
+| Server-stored appearance | Deferred — localStorage first |
+
+---
+
+## Phase 1 — Remove org themes (API) ✅
+
+- [x] Drop `themes` table migration
+- [x] Delete `Theme` model, `ThemesController`, views, routes, specs, factory
+- [x] Remove `organization.theme` from JSON; `set_default_theme` callback
+- [x] Remove Theme abilities (admin, waiter, kitchen, cash)
+- [x] Update Swagger helper (regenerate `swagger.yaml` when convenient)
+
+---
+
+## Phase 2 — Dark mode foundation (React) ✅
+
+- [x] CSS tokens in `globals.css` + `@custom-variant dark`
+- [x] `appearance.ts` — light / dark / system + localStorage
+- [x] `AppearanceScript` — prevent flash on load
+- [x] `AppearanceProvider` + `useAppearance`
+- [x] Settings → Appearance card
+
+---
+
+## Phase 3 — Shell styling
+
+- [x] Sidebar, header, Card, Buttons, Inputs, AuthShell
+- [ ] Toolbar, Product lists, kitchen board (incremental as pages are touched)
+- [ ] Audit remaining hardcoded `bg-white` / `text-gray-*` in app routes
+
+---
+
+## Phase 4 — Tests & docs
+
+- [ ] Unit: `resolveDarkMode`, `readStoredAppearance`
+- [ ] Optional E2E: toggle in settings persists after reload
+- [ ] Remove theme references from plan 06 (Organizations UI)
+
+---
+
+## Definition of done
+
+- [x] No `themes` API or DB table
+- [x] User can pick Light / Dark / System in Settings
+- [x] App shell readable in both modes
+- [ ] No references to org theme in active frontend types
+
+---
+
+## References
+
+- Removed: `app/controllers/api/v1/organizations/themes_controller.rb`
+- Added: `src/app/_lib/appearance.ts`, `AppearanceProvider.tsx`
+- Angular legacy (ignored): `ubuteco_spa/.../theme-customizer`

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -18,6 +18,7 @@ Backend work: [`ubuteco_api/docs/plans`](../../../ubuteco_api/docs/plans/README.
 | 9 | [Frontend performance](./09-frontend-performance.md) | P2 | — |
 | 10 | [Browser document titles](./10-document-titles.md) | P2 | — |
 | 11 | [Inventory UI](./11-inventory-ui.md) | P2 | [09-inventory-stock](../../../ubuteco_api/docs/plans/09-inventory-stock.md) |
+| 12 | [Appearance — dark mode](./12-appearance-dark-mode.md) | P2 | — |
 | 3 | [Subscription plans](./03-subscription-plans.md) | P2 | [API](../../../ubuteco_api/docs/plans/03-subscription-plans.md) |
 
 Platform hardening (API): [05-platform-hardening](../../../ubuteco_api/docs/plans/05-platform-hardening.md).

--- a/src/app/_components/AppearanceProvider.tsx
+++ b/src/app/_components/AppearanceProvider.tsx
@@ -16,8 +16,13 @@ type AppearanceContextValue = {
 
 const AppearanceContext = createContext<AppearanceContextValue | null>(null);
 
+function readInitialMode(): AppearanceMode {
+  if (typeof window === "undefined") return "system";
+  return readStoredAppearance();
+}
+
 export function AppearanceProvider({children}: {children: ReactNode}) {
-  const [mode, setModeState] = useState<AppearanceMode>("system");
+  const [mode, setModeState] = useState<AppearanceMode>(readInitialMode);
   const [isDark, setIsDark] = useState(false);
 
   useEffect(() => {
@@ -25,8 +30,13 @@ export function AppearanceProvider({children}: {children: ReactNode}) {
     setModeState(stored);
     applyAppearance(stored);
     setIsDark(document.documentElement.classList.contains("dark"));
+  }, []);
 
-    if (stored !== "system") return;
+  useEffect(() => {
+    applyAppearance(mode);
+    setIsDark(document.documentElement.classList.contains("dark"));
+
+    if (mode !== "system") return;
 
     const media = window.matchMedia("(prefers-color-scheme: dark)");
     const syncSystem = () => {
@@ -36,7 +46,7 @@ export function AppearanceProvider({children}: {children: ReactNode}) {
 
     media.addEventListener("change", syncSystem);
     return () => media.removeEventListener("change", syncSystem);
-  }, []);
+  }, [mode]);
 
   const setMode = (next: AppearanceMode) => {
     setModeState(next);

--- a/src/app/_components/AppearanceProvider.tsx
+++ b/src/app/_components/AppearanceProvider.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import {createContext, ReactNode, useContext, useEffect, useMemo, useState} from "react";
+import {
+  AppearanceMode,
+  applyAppearance,
+  readStoredAppearance,
+  storeAppearance,
+} from "@/app/_lib/appearance";
+
+type AppearanceContextValue = {
+  mode: AppearanceMode;
+  setMode: (mode: AppearanceMode) => void;
+  isDark: boolean;
+};
+
+const AppearanceContext = createContext<AppearanceContextValue | null>(null);
+
+export function AppearanceProvider({children}: {children: ReactNode}) {
+  const [mode, setModeState] = useState<AppearanceMode>("system");
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const stored = readStoredAppearance();
+    setModeState(stored);
+    applyAppearance(stored);
+    setIsDark(document.documentElement.classList.contains("dark"));
+
+    if (stored !== "system") return;
+
+    const media = window.matchMedia("(prefers-color-scheme: dark)");
+    const syncSystem = () => {
+      applyAppearance("system");
+      setIsDark(document.documentElement.classList.contains("dark"));
+    };
+
+    media.addEventListener("change", syncSystem);
+    return () => media.removeEventListener("change", syncSystem);
+  }, []);
+
+  const setMode = (next: AppearanceMode) => {
+    setModeState(next);
+    storeAppearance(next);
+    setIsDark(document.documentElement.classList.contains("dark"));
+  };
+
+  const value = useMemo(() => ({mode, setMode, isDark}), [mode, isDark]);
+
+  return <AppearanceContext.Provider value={value}>{children}</AppearanceContext.Provider>;
+}
+
+export function useAppearance(): AppearanceContextValue {
+  const context = useContext(AppearanceContext);
+  if (!context) {
+    throw new Error("useAppearance must be used within AppearanceProvider");
+  }
+  return context;
+}

--- a/src/app/_components/AppearanceScript.tsx
+++ b/src/app/_components/AppearanceScript.tsx
@@ -1,0 +1,13 @@
+export function AppearanceScript() {
+  const script = `
+    (function () {
+      var key = "ubuteco-appearance";
+      var mode = localStorage.getItem(key);
+      var dark = mode === "dark" || (mode !== "light" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+      if (dark) document.documentElement.classList.add("dark");
+      document.documentElement.dataset.appearance = mode || "system";
+    })();
+  `;
+
+  return <script dangerouslySetInnerHTML={{__html: script}} />;
+}

--- a/src/app/_components/AppearanceScript.tsx
+++ b/src/app/_components/AppearanceScript.tsx
@@ -1,13 +1,15 @@
 export function AppearanceScript() {
   const script = `
     (function () {
-      var key = "ubuteco-appearance";
-      var mode = localStorage.getItem(key);
-      var dark = mode === "dark" || (mode !== "light" && window.matchMedia("(prefers-color-scheme: dark)").matches);
-      if (dark) document.documentElement.classList.add("dark");
-      document.documentElement.dataset.appearance = mode || "system";
+      try {
+        var key = "ubuteco-appearance";
+        var mode = localStorage.getItem(key);
+        var resolved = mode === "dark" || (mode !== "light" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+        document.documentElement.classList.toggle("dark", resolved);
+        document.documentElement.dataset.appearance = mode || "system";
+      } catch (e) {}
     })();
   `;
 
-  return <script dangerouslySetInnerHTML={{__html: script}} />;
+  return <script dangerouslySetInnerHTML={{__html: script}}/>;
 }

--- a/src/app/_components/AuthShell.tsx
+++ b/src/app/_components/AuthShell.tsx
@@ -10,11 +10,11 @@ type Props = {
 
 export function AuthShell({title, subtitle, children, footer}: Props) {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100 p-6">
-      <div className="w-full max-w-md bg-white rounded-2xl shadow-lg p-8 space-y-6">
+    <div className="flex min-h-screen items-center justify-center bg-background p-6">
+      <div className="w-full max-w-md space-y-6 rounded-2xl border border-border bg-surface p-8 shadow-lg">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">{title}</h1>
-          <p className="text-sm text-gray-500 mt-1">{subtitle}</p>
+          <h1 className="text-2xl font-bold text-foreground">{title}</h1>
+          <p className="mt-1 text-sm text-muted">{subtitle}</p>
         </div>
         {children}
         {footer}
@@ -25,8 +25,8 @@ export function AuthShell({title, subtitle, children, footer}: Props) {
 
 export function AuthFooterLink({href, children}: { href: string; children: ReactNode }) {
   return (
-    <p className="text-center text-sm text-gray-600">
-      <Link href={href} className="font-medium text-blue-600 hover:text-blue-700">
+    <p className="text-center text-sm text-muted">
+      <Link href={href} className="font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300">
         {children}
       </Link>
     </p>

--- a/src/app/_components/Buttons.tsx
+++ b/src/app/_components/Buttons.tsx
@@ -27,10 +27,10 @@ const baseStyles =
   "inline-flex items-center justify-center font-medium transition rounded-2xl focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none";
 
 const variantStyles: Record<ButtonVariant, string> = {
-  default: "bg-black text-white hover:bg-black/80 focus:ring-black",
-  outline: "border border-gray-300 bg-white hover:bg-gray-50 focus:ring-gray-400",
-  secondary: "bg-gray-100 text-gray-900 hover:bg-gray-200 focus:ring-gray-400",
-  ghost: "bg-transparent hover:bg-gray-100 focus:ring-gray-400",
+  default: "bg-black text-white hover:bg-black/80 focus:ring-black dark:bg-white dark:text-black dark:hover:bg-white/90",
+  outline: "border border-border bg-surface hover:bg-surface-muted focus:ring-gray-400",
+  secondary: "bg-surface-muted text-foreground hover:bg-border focus:ring-gray-400",
+  ghost: "bg-transparent hover:bg-surface-muted focus:ring-gray-400",
   danger: "bg-red-600 text-white hover:bg-red-700 focus:ring-red-600",
 };
 

--- a/src/app/_components/Card.tsx
+++ b/src/app/_components/Card.tsx
@@ -11,9 +11,9 @@ type CardProps = {
 export function Card({title, children, className}: CardProps) {
   return (
     <div
-      className={`bg-white p-6 rounded-2xl shadow-sm transition-transform duration-200 hover:-translate-y-1 ${className}`}
+      className={`rounded-2xl bg-surface p-6 shadow-sm transition-transform duration-200 hover:-translate-y-1 ${className}`}
     >
-      <h3 className="font-semibold text-lg mb-2">{title}</h3>
+      <h3 className="mb-2 text-lg font-semibold text-foreground">{title}</h3>
       {children}
     </div>
   )

--- a/src/app/_components/ConfirmDialog.tsx
+++ b/src/app/_components/ConfirmDialog.tsx
@@ -31,8 +31,8 @@ export function ConfirmDialog({
     <AnimatePresence>
       {open && (
         <ModalWrapper onClose={onCancel}>
-          <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
-          <p className="mt-2 text-sm text-gray-600">{message}</p>
+          <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+          <p className="mt-2 text-sm text-muted">{message}</p>
           <div className="mt-6 flex justify-end gap-2">
             <Buttons type="button" variant="outline" onClick={onCancel} disabled={loading}>
               {cancelLabel}

--- a/src/app/_components/Inputs.tsx
+++ b/src/app/_components/Inputs.tsx
@@ -43,15 +43,18 @@ export function Input(props: InputProps) {
       rounded-xl
       border
       border-gray-200
-      bg-white
+      bg-surface
       py-2.5
       pl-10
       pr-4
       text-sm
+      text-foreground
       outline-none
       focus:border-blue-500
       focus:ring-2
       focus:ring-blue-100
+      dark:border-border
+      dark:focus:ring-blue-900
      ${props.className || ""}
     `}
   />)
@@ -73,15 +76,18 @@ export function Textarea(props: TextAreaProps) {
       rounded-xl
       border
       border-gray-200
-      bg-white
+      bg-surface
       py-2.5
       pl-10
       pr-4
       text-sm
+      text-foreground
       outline-none
       focus:border-blue-500
       focus:ring-2
       focus:ring-blue-100
+      dark:border-border
+      dark:focus:ring-blue-900
      ${props.className}
     `}/>)
 }

--- a/src/app/_components/Label.tsx
+++ b/src/app/_components/Label.tsx
@@ -8,7 +8,7 @@ type LabelProps = {
 export function Label({label, children}: LabelProps) {
   return (
     <div className="space-y-1">
-      <label htmlFor={label.toString().toLowerCase()} className="text-sm font-medium text-gray-700">{label}</label>
+      <label htmlFor={label.toString().toLowerCase()} className="text-sm font-medium text-foreground">{label}</label>
       {children}
     </div>
   );

--- a/src/app/_components/Loading.tsx
+++ b/src/app/_components/Loading.tsx
@@ -8,7 +8,7 @@ export function Loading() {
       {[0, 1, 2].map((i) => (
         <motion.div
           key={i}
-          className="w-3 h-3 bg-black rounded-full"
+          className="h-3 w-3 rounded-full bg-foreground"
           animate={{
             y: [0, -10, 0],
           }}

--- a/src/app/_components/ModalWrapper.tsx
+++ b/src/app/_components/ModalWrapper.tsx
@@ -24,7 +24,7 @@ export default function ModalWrapper({
       />
 
       <motion.div
-        className="relative bg-white p-6 rounded-xl w-[500px] shadow-xl"
+        className="relative w-[500px] rounded-xl border border-border bg-surface p-6 shadow-xl"
         initial={{scale: 0.95, opacity: 0}}
         animate={{scale: 1, opacity: 1}}
         exit={{scale: 0.95, opacity: 0}}

--- a/src/app/_components/Selects.tsx
+++ b/src/app/_components/Selects.tsx
@@ -16,15 +16,18 @@ export function Select({name, className, value, onChange, disabled, children}: S
       rounded-xl
       border
       border-gray-200
-      bg-white
+      bg-surface
       py-2.5
       pl-10
       pr-4
       text-sm
+      text-foreground
       outline-none
       focus:border-blue-500
       focus:ring-2
       focus:ring-blue-100
+      dark:border-border
+      dark:focus:ring-blue-900
      ${className}
     `}
                  onChange={(e) => onChange(e.target.value)}

--- a/src/app/_components/SidebarLayout.tsx
+++ b/src/app/_components/SidebarLayout.tsx
@@ -52,22 +52,17 @@ export default function SidebarLayout({children}: { children: ReactNode }) {
   const allMenuItems = [
     {label: "Dashboard", icon: faHouse, link: "/"},
     {label: "Kitchen", icon: faUtensils, link: "/kitchen", kitchen: true},
-
     {label: "Beers", icon: faBeer, link: "/beers"},
     {label: "Beer Styles", icon: faBeer, link: "/beer-styles"},
     {label: "Drinks", icon: faGlassMartini, link: "/drinks"},
     {label: "Wines", icon: faWineBottle, link: "/wines"},
     {label: "Wine Styles", icon: faWineBottle, link: "/wine-styles"},
-
     {label: "Dishes", icon: faHamburger, link: "/dishes"},
     {label: "Food", icon: faHamburger, link: "/foods"},
-
     {label: "Makers", icon: faIndustry, link: "/makers"},
-
     {label: "Orders", icon: faCartShopping, link: "/orders"},
     {label: "Organizations", icon: faBuilding, link: "/organizations"},
     {label: "Tables", icon: faChair, link: "/tables"},
-
     {label: "Users", icon: faUsers, link: "/users"},
     {label: "Settings", icon: faGear, link: "/settings"},
   ];
@@ -82,12 +77,11 @@ export default function SidebarLayout({children}: { children: ReactNode }) {
     `px-3 py-2 rounded-md text-sm font-medium transition-colors ${
       pathname === path
         ? "bg-blue-600 text-white"
-        : "text-gray-700 hover:bg-gray-200"
-    }`
+        : "text-gray-700 hover:bg-gray-200 dark:text-gray-200 dark:hover:bg-gray-800"
+    }`;
 
   return (
-    <div className="flex h-screen bg-gray-100">
-      {/* Sidebar */}
+    <div className="flex h-screen bg-background">
       <AnimatePresence>
         {isOpen && (
           <motion.aside
@@ -95,41 +89,37 @@ export default function SidebarLayout({children}: { children: ReactNode }) {
             animate={{width: 260, opacity: 1}}
             exit={{width: 0, opacity: 0}}
             transition={{duration: 0.25}}
-            className="bg-white shadow-xl flex flex-col justify-between overflow-hidden"
+            className="flex flex-col justify-between overflow-hidden border-r border-border bg-surface shadow-xl"
           >
             <div>
-              <div className="p-6 border-b">
-                <h1 className="text-xl font-bold tracking-tight">Ubuteco</h1>
-                <p className="text-sm text-gray-500">
+              <div className="border-b border-border p-6">
+                <h1 className="text-xl font-bold tracking-tight text-foreground">Ubuteco</h1>
+                <p className="text-sm text-muted">
                   {user?.name ?? user?.email ?? "Admin Panel"}
                 </p>
                 {isSuperAdmin && (
-                  <p className="mt-1 text-xs font-medium text-amber-700">
+                  <p className="mt-1 text-xs font-medium text-amber-700 dark:text-amber-400">
                     Platform — catalog read-only
                   </p>
                 )}
               </div>
 
-              <nav className="p-4 space-y-2">
-                {menuItems.map((item) => {
-                  return (
-                    <Link
-                      href={item.link}
-                      key={item.label}
-                      className={
-                        `flex items-center gap-3 w-full px-4 py-3 rounded-2xl hover:bg-gray-100 transition text-left ${linkClass(item.link)}`
-                      }
-                    >
-                      <FontAwesomeIcon icon={item.icon} className="text-base"/>
-                      <span className="text-sm font-medium">{item.label}</span>
-                    </Link>
-                  );
-                })}
+              <nav className="space-y-2 p-4">
+                {menuItems.map((item) => (
+                  <Link
+                    href={item.link}
+                    key={item.label}
+                    className={`flex w-full items-center gap-3 rounded-2xl px-4 py-3 text-left transition hover:bg-surface-muted ${linkClass(item.link)}`}
+                  >
+                    <FontAwesomeIcon icon={item.icon} className="text-base"/>
+                    <span className="text-sm font-medium">{item.label}</span>
+                  </Link>
+                ))}
               </nav>
             </div>
 
-            <div className="p-4 border-t">
-              <Buttons onClick={handleLogout} className="w-full rounded-2xl flex items-center gap-2">
+            <div className="border-t border-border p-4">
+              <Buttons onClick={handleLogout} className="flex w-full items-center gap-2 rounded-2xl">
                 <FontAwesomeIcon icon={faRightFromBracket}/> Sign out
               </Buttons>
             </div>
@@ -137,10 +127,8 @@ export default function SidebarLayout({children}: { children: ReactNode }) {
         )}
       </AnimatePresence>
 
-      {/* Main Content */}
-      <div className="flex-1 flex flex-col">
-        {/* Topbar */}
-        <header className="bg-white border-b p-4 flex items-center justify-between">
+      <div className="flex flex-1 flex-col">
+        <header className="flex items-center justify-between border-b border-border bg-surface p-4">
           <div className="flex items-center gap-3">
             <Buttons
               variant="outline"
@@ -150,13 +138,15 @@ export default function SidebarLayout({children}: { children: ReactNode }) {
             >
               <FontAwesomeIcon icon={faBars}/>
             </Buttons>
-            <h2 className="text-lg font-semibold">{getPageTitle(pathname)}</h2>
+            <h2 className="text-lg font-semibold text-foreground">{getPageTitle(pathname)}</h2>
           </div>
 
           <Link
             href="/settings"
-            className={`flex items-center gap-2 rounded-2xl border px-3 py-2 transition hover:bg-gray-50 ${
-              pathname === "/settings" ? "border-blue-200 bg-blue-50" : "border-gray-200"
+            className={`flex items-center gap-2 rounded-2xl border px-3 py-2 transition hover:bg-surface-muted ${
+              pathname === "/settings"
+                ? "border-blue-300 bg-blue-50 dark:border-blue-700 dark:bg-blue-950/40"
+                : "border-border"
             }`}
           >
             <span
@@ -165,18 +155,16 @@ export default function SidebarLayout({children}: { children: ReactNode }) {
             >
               {user ? userInitials(user) : <FontAwesomeIcon icon={faUser}/>}
             </span>
-            <span className="hidden max-w-[140px] truncate text-sm font-medium text-gray-800 sm:inline">
+            <span className="hidden max-w-[140px] truncate text-sm font-medium text-foreground sm:inline">
               {user?.name ?? user?.email ?? "My account"}
             </span>
           </Link>
         </header>
 
-        {/* Page Content */}
-        <main className="flex-1 p-6 overflow-auto">
+        <main className="flex-1 overflow-auto p-6">
           {children}
         </main>
       </div>
     </div>
   );
 }
-

--- a/src/app/_lib/appearance.ts
+++ b/src/app/_lib/appearance.ts
@@ -1,0 +1,27 @@
+export type AppearanceMode = "light" | "dark" | "system";
+
+export const APPEARANCE_STORAGE_KEY = "ubuteco-appearance";
+
+export function resolveDarkMode(mode: AppearanceMode): boolean {
+  if (mode === "dark") return true;
+  if (mode === "light") return false;
+  return window.matchMedia("(prefers-color-scheme: dark)").matches;
+}
+
+export function readStoredAppearance(): AppearanceMode {
+  if (typeof window === "undefined") return "system";
+  const value = localStorage.getItem(APPEARANCE_STORAGE_KEY);
+  if (value === "light" || value === "dark" || value === "system") return value;
+  return "system";
+}
+
+export function applyAppearance(mode: AppearanceMode): void {
+  const root = document.documentElement;
+  root.classList.toggle("dark", resolveDarkMode(mode));
+  root.dataset.appearance = mode;
+}
+
+export function storeAppearance(mode: AppearanceMode): void {
+  localStorage.setItem(APPEARANCE_STORAGE_KEY, mode);
+  applyAppearance(mode);
+}

--- a/src/app/_types/organization.ts
+++ b/src/app/_types/organization.ts
@@ -7,7 +7,6 @@ export interface Organization extends BaseModel {
   cnpj?: string;
   phone?: string;
   logo?: PictureFromS3;
-  theme_id?: number;
   user_id?: number;
   operational_status?: OrganizationOperationalStatus;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,7 +11,8 @@
   --muted: #6b7280;
 }
 
-.dark {
+html.dark {
+  color-scheme: dark;
   --background: #030712;
   --foreground: #f3f4f6;
   --surface: #111827;
@@ -35,4 +36,36 @@ body {
   background-color: var(--color-background);
   color: var(--color-foreground);
   font-family: Roboto, sans-serif;
+}
+
+/* Legacy hardcoded grays until pages migrate to semantic tokens */
+html.dark .text-gray-900,
+html.dark .text-gray-800,
+html.dark .text-gray-700 {
+  color: var(--foreground);
+}
+
+html.dark .text-gray-600,
+html.dark .text-gray-500 {
+  color: var(--muted);
+}
+
+html.dark .text-gray-400 {
+  color: var(--muted);
+  opacity: 0.85;
+}
+
+html.dark .bg-white {
+  background-color: var(--surface);
+}
+
+html.dark .bg-gray-50,
+html.dark .bg-gray-100 {
+  background-color: var(--surface-muted);
+}
+
+html.dark .border-gray-200,
+html.dark .border-gray-300,
+html.dark .border-dashed.border-gray-300 {
+  border-color: var(--border);
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,26 +1,38 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 :root {
-    --background: #ffffff;
-    --foreground: rgba(0, 0, 0, 0.76);
+  --background: #f3f4f6;
+  --foreground: #111827;
+  --surface: #ffffff;
+  --surface-muted: #f9fafb;
+  --border: #e5e7eb;
+  --muted: #6b7280;
+}
+
+.dark {
+  --background: #030712;
+  --foreground: #f3f4f6;
+  --surface: #111827;
+  --surface-muted: #1f2937;
+  --border: #374151;
+  --muted: #9ca3af;
 }
 
 @theme inline {
-    --color-background: var(--background);
-    --color-foreground: var(--foreground);
-    --font-sans: var(--font-roboto-sans);
-    --font-mono: var(--font-roboto-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-    :root {
-        --background: #0a0a0a;
-        --foreground: rgba(0, 0, 0, 0.76);;
-    }
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-surface: var(--surface);
+  --color-surface-muted: var(--surface-muted);
+  --color-border: var(--border);
+  --color-muted: var(--muted);
+  --font-sans: var(--font-roboto-sans);
+  --font-mono: var(--font-geist-mono);
 }
 
 body {
-    background-color: var(--color-background);
-    color: var(--color-foreground);
-    font-family: Roboto, sans-serif;
+  background-color: var(--color-background);
+  color: var(--color-foreground);
+  font-family: Roboto, sans-serif;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,20 +1,8 @@
-"use client"
-
 import {Roboto, Roboto_Mono} from "next/font/google";
 import "./globals.css";
 
-import {config} from '@fortawesome/fontawesome-svg-core'
-import '@fortawesome/fontawesome-svg-core/styles.css'
-import AuthGuard from "@/app/_components/AuthGuard";
-import AuthHydrator from "@/app/_components/AuthHydrator";
-import {AppearanceProvider} from "@/app/_components/AppearanceProvider";
 import {AppearanceScript} from "@/app/_components/AppearanceScript";
-import SidebarLayout from "@/app/_components/SidebarLayout";
-import {ToastProvider} from "@/app/_components/Toast/ToastProvider";
-import {Provider} from "react-redux";
-import {store} from "./_store"
-
-config.autoAddCss = false
+import {Providers} from "@/app/providers";
 
 const robotoSans = Roboto({
   variable: "--font-roboto-sans",
@@ -26,38 +14,19 @@ const robotoMono = Roboto_Mono({
   subsets: ["latin"],
 });
 
-// export const metadata: Metadata = {
-//   title: "Ubuteco React App",
-//   description: "Ubuteco React App",
-// };
-
 export default function RootLayout({
-                                     children,
-                                   }: Readonly<{
+  children,
+}: Readonly<{
   children: React.ReactNode;
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-    <head>
-      <AppearanceScript/>
-    </head>
-    <body
-      className={`${robotoSans.variable} ${robotoMono.variable} antialiased`}
-    >
-    <Provider store={store}>
-      <AppearanceProvider>
-      <ToastProvider>
-        <AuthHydrator>
-          <AuthGuard>
-            <SidebarLayout>
-              {children}
-            </SidebarLayout>
-          </AuthGuard>
-        </AuthHydrator>
-      </ToastProvider>
-      </AppearanceProvider>
-    </Provider>
-    </body>
+      <head>
+        <AppearanceScript/>
+      </head>
+      <body className={`${robotoSans.variable} ${robotoMono.variable} antialiased`}>
+        <Providers>{children}</Providers>
+      </body>
     </html>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,8 @@ import {config} from '@fortawesome/fontawesome-svg-core'
 import '@fortawesome/fontawesome-svg-core/styles.css'
 import AuthGuard from "@/app/_components/AuthGuard";
 import AuthHydrator from "@/app/_components/AuthHydrator";
+import {AppearanceProvider} from "@/app/_components/AppearanceProvider";
+import {AppearanceScript} from "@/app/_components/AppearanceScript";
 import SidebarLayout from "@/app/_components/SidebarLayout";
 import {ToastProvider} from "@/app/_components/Toast/ToastProvider";
 import {Provider} from "react-redux";
@@ -35,11 +37,15 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
+    <head>
+      <AppearanceScript/>
+    </head>
     <body
       className={`${robotoSans.variable} ${robotoMono.variable} antialiased`}
     >
     <Provider store={store}>
+      <AppearanceProvider>
       <ToastProvider>
         <AuthHydrator>
           <AuthGuard>
@@ -49,6 +55,7 @@ export default function RootLayout({
           </AuthGuard>
         </AuthHydrator>
       </ToastProvider>
+      </AppearanceProvider>
     </Provider>
     </body>
     </html>

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import {ReactNode} from "react";
+import {config} from "@fortawesome/fontawesome-svg-core";
+import "@fortawesome/fontawesome-svg-core/styles.css";
+import {Provider} from "react-redux";
+import {store} from "@/app/_store";
+import {AppearanceProvider} from "@/app/_components/AppearanceProvider";
+import {ToastProvider} from "@/app/_components/Toast/ToastProvider";
+import AuthHydrator from "@/app/_components/AuthHydrator";
+import AuthGuard from "@/app/_components/AuthGuard";
+import SidebarLayout from "@/app/_components/SidebarLayout";
+
+config.autoAddCss = false;
+
+export function Providers({children}: {children: ReactNode}) {
+  return (
+    <Provider store={store}>
+      <AppearanceProvider>
+        <ToastProvider>
+          <AuthHydrator>
+            <AuthGuard>
+              <SidebarLayout>{children}</SidebarLayout>
+            </AuthGuard>
+          </AuthHydrator>
+        </ToastProvider>
+      </AppearanceProvider>
+    </Provider>
+  );
+}

--- a/src/app/settings/components/AppearanceSettings.tsx
+++ b/src/app/settings/components/AppearanceSettings.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import {AppearanceMode} from "@/app/_lib/appearance";
+import {useAppearance} from "@/app/_components/AppearanceProvider";
+
+const OPTIONS: {value: AppearanceMode; label: string; description: string}[] = [
+  {value: "light", label: "Light", description: "Always use light mode"},
+  {value: "dark", label: "Dark", description: "Always use dark mode"},
+  {value: "system", label: "System", description: "Match your device setting"},
+];
+
+export function AppearanceSettings() {
+  const {mode, setMode} = useAppearance();
+
+  return (
+    <div className="grid gap-2 sm:grid-cols-3">
+      {OPTIONS.map((option) => {
+        const active = mode === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => setMode(option.value)}
+            className={`rounded-xl border p-4 text-left transition ${
+              active
+                ? "border-blue-500 bg-blue-50 dark:border-blue-400 dark:bg-blue-950/40"
+                : "border-border bg-surface hover:bg-surface-muted"
+            }`}
+          >
+            <span className="block text-sm font-semibold text-foreground">{option.label}</span>
+            <span className="mt-1 block text-xs text-muted">{option.description}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -16,6 +16,7 @@ import {updateAuthenticatedUser} from "@/app/_store/features/auth/authSlice";
 import {signOut} from "@/app/_store/features/auth/authThunks";
 import {useAuthCapabilities} from "@/app/_hooks/useAuthCapabilities";
 import {User} from "@/app/_types";
+import {AppearanceSettings} from "@/app/settings/components/AppearanceSettings";
 
 export default function SettingsPage() {
   const router = useRouter();
@@ -240,6 +241,13 @@ export default function SettingsPage() {
             </Buttons>
           </div>
         </form>
+      </Card>
+
+      <Card title="Appearance" className="hover:translate-y-0">
+        <p className="mb-4 text-sm text-muted">
+          Choose light, dark, or follow your system preference. Saved on this device.
+        </p>
+        <AppearanceSettings/>
       </Card>
 
       <Card title="Plan" className="hover:translate-y-0">


### PR DESCRIPTION
## Summary

Replaces the abandoned org-level theme customizer with **user dark mode**:

- **Settings → Appearance:** Light, Dark, or System (follows OS)
- Preference stored in `localStorage` (`ubuteco-appearance`)
- `AppearanceScript` prevents flash of wrong theme on load
- CSS tokens + `dark` variant in `globals.css`
- Shell updated: sidebar, header, Card, Buttons, Inputs, auth pages

Org branding remains **logo + name** (Organizations UI plan 06) — not sidebar colors.

## Out of scope

- Styling every inner page (orders, kitchen cards) — incremental follow-up
- Server-persisted appearance preference

## Test plan

- [ ] Settings → toggle Light / Dark / System — shell updates immediately
- [ ] Reload page — preference persists, no white flash in dark mode
- [ ] Login/signup pages readable in both modes
- [ ] DevTools: no requests send org theme fields

## Companion PR

ubuteco_api: https://github.com/Sartori-RIA/ubuteco_api/pull/30


Made with [Cursor](https://cursor.com)