### PR TITLE
docs: add AI context structure for assistants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+# AGENTS.md — ubuteco-react
+
+Instructions for AI assistants working in this repository.
+
+## Stack
+
+- Next.js 16 (App Router) + React 19 + TypeScript
+- Tailwind CSS 4, Redux Toolkit, Font Awesome
+- Real-time: `@rails/actioncable` → AnyCable (not Puma directly)
+
+## Backend
+
+All data comes from **[ubuteco_api](../ubuteco_api)** (`/api/v1/...`). See API [AGENTS.md](../ubuteco_api/AGENTS.md) and [docs/context](../ubuteco_api/docs/context/).
+
+Angular `ubuteco_spa` is **abandoned** — do not reference or port from it.
+
+## Before you code
+
+1. Read [docs/plans/README.md](docs/plans/README.md) — pick **one plan**, check status and companion API plan.
+2. Read [docs/context/frontend-map.md](docs/context/frontend-map.md) for folder conventions.
+3. Read [docs/dev-setup.md](docs/dev-setup.md) for ports and env vars.
+
+## Branching
+
+- **One plan = one branch:** `feature/<plan-slug>` (e.g. `feature/locale-and-currency`).
+- Do not mix unrelated plans on the same branch.
+- Docs-only changes: `docs/<topic>` (e.g. `docs/ai-context`).
+
+## Do not (unless explicitly asked)
+
+- Commit secrets (`.env`).
+- Force-push to `main`.
+- Run broad UI refactors outside the active plan scope.
+- Reintroduce org theme/color customizer (removed; use user dark mode in settings).
+
+## Conventions
+
+- Server layout: `src/app/layout.tsx` (AppearanceScript + Providers).
+- Client providers: `src/app/providers.tsx`.
+- Auth: JWT in localStorage; `AuthGuard` + `useAuthCapabilities()`.
+- Roles: `src/app/_lib/auth-roles.ts` — mirror API abilities in UX, not as security boundary.
+- API calls: `src/app/_services/api-fetch.ts` + domain services.
+- Money display: prefer `useMoneyFormat()` / `formatMoney` from `_lib/format.ts` — avoid hardcoded `BRL`/`USD`.
+- Dark mode: class `dark` on `<html>`, tokens in `globals.css`.
+
+## Key paths
+
+| Area | Path |
+|------|------|
+| Plans | `docs/plans/` |
+| Context | `docs/context/` |
+| Pages | `src/app/**/page.tsx` |
+| Shared UI | `src/app/_components/` |
+| Hooks | `src/app/_hooks/` |
+| Redux | `src/app/_store/` |
+
+## Companion repo
+
+API plans and endpoints: [ubuteco_api/docs/plans](../ubuteco_api/docs/plans/README.md)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The previous Angular app ([ubuteco_spa](https://github.com/Sartori-RIA/ubuteco_s
 
 **Improvement plans (frontend):** [docs/plans/README.md](docs/plans/README.md) — organizations, users, settings, testing, performance, and more.
 
+**AI / contributors:** [AGENTS.md](AGENTS.md) · [docs/context/](docs/context/) · [docs/dev-setup.md](docs/dev-setup.md)
+
 
 ## Getting Started
 

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -1,0 +1,42 @@
+# Architecture — React (frontend)
+
+Staff UI for restaurants: orders, kitchen, catalog, settings. All business rules are enforced by **ubuteco_api** — this app handles auth, routing, formatting, and UX.
+
+## Data flow
+
+```
+page.tsx → hooks / Redux thunks → _services/*.ts → api-fetch.ts → Rails API
+                ↓
+         AuthGuard / role helpers (client-side only)
+```
+
+Real-time kitchen: `useKitchenCable` → AnyCable WebSocket (`CABLE_URL`).
+
+## Auth state
+
+- Redux: `authSlice` + `authThunks` (`signIn`, `fetchCurrentUser`, …)
+- Persistence: `localStorage` via `_lib/auth-storage.ts`
+- Current user includes nested `organization` when API embeds it
+
+## Multi-tenant UX
+
+- `requiresOrganization()` + `hasOrganization()` in `AuthGuard` → redirect `/forbidden`
+- Super admin: read-only catalog mutations blocked via `canMutateOperationalData()` and route guards
+- Kitchen-only users: restricted to `/kitchen` and `/settings`
+
+## Appearance
+
+- User preference (not org): Light / Dark / System in Settings
+- `AppearanceScript` (beforeInteractive) + `AppearanceProvider`
+- CSS variables in `globals.css`; Tailwind `@custom-variant dark`
+
+## Regional settings (plan 02)
+
+- Org-level locale, currency, timezone via `useOrganizationSettings()`
+- Formatting: `useMoneyFormat()`, `_lib/format.ts`
+
+## Related docs
+
+- [frontend-map.md](./frontend-map.md)
+- [dev-setup.md](../dev-setup.md)
+- API architecture: [ubuteco_api/docs/context/architecture.md](../../../ubuteco_api/docs/context/architecture.md)

--- a/docs/context/frontend-map.md
+++ b/docs/context/frontend-map.md
@@ -1,0 +1,66 @@
+# Frontend map
+
+## App Router structure
+
+```
+src/app/
+  layout.tsx          # Server root: fonts, AppearanceScript, Providers
+  providers.tsx       # Client: Redux, Auth, Sidebar shell
+  globals.css         # Design tokens + dark mode
+  page.tsx            # Dashboard (/)
+  login/              # Public auth
+  settings/           # Profile, appearance, regional settings, …
+  kitchen/            # Real-time queue
+  orders/             # Order CRUD + items
+  beers/ wines/ …     # Catalog CRUD (resource pattern)
+  _components/        # Shared UI (Buttons, Card, AuthGuard, …)
+  _hooks/             # Reusable hooks
+  _lib/               # Pure helpers (auth-roles, format, money, …)
+  _services/          # API clients
+  _store/             # Redux slices + thunks
+  _types/             # TypeScript interfaces
+```
+
+## Naming patterns
+
+| Pattern | Example |
+|---------|---------|
+| List page | `beers/page.tsx` |
+| Detail | `beers/[id]/page.tsx` |
+| New / edit | `beers/new/page.tsx`, `beers/[id]/edit/page.tsx` |
+| Local components | `beers/components/` or colocated |
+| API service | `_services/beers.service.ts` |
+| Redux feature | `_store/features/beers/` |
+
+## Shared components
+
+Import from `@/app/_components` barrel when possible.
+
+Key shells:
+
+- `SidebarLayout` — authenticated chrome + nav
+- `AuthGuard` — auth + org + role redirects
+- `AuthHydrator` — restores session on load
+
+## API calls
+
+Always use `apiFetch` — handles base URL, JWT header, JSON errors (`ApiError`).
+
+```typescript
+import { apiFetch } from "@/app/_services/api-fetch";
+```
+
+## Money and dates
+
+- Prefer `useMoneyFormat()` in client components
+- `formatDate` in `_lib/format.ts` for datetimes with org timezone
+- `_lib/format-date.ts` — calendar-day parsing for date-only fields (avoid TZ shift on `valid_until`)
+
+## Do not use
+
+- `ubuteco_spa` (Angular) patterns or paths
+- Org theme color API (removed; dark mode is user-level)
+
+## Plans
+
+Feature work is tracked in [docs/plans/](../plans/README.md). One branch per plan.

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -1,0 +1,54 @@
+# Development setup — ubuteco-react
+
+## Prerequisites
+
+- Node.js (LTS), npm
+- Running **[ubuteco_api](../ubuteco_api)** (REST + AnyCable)
+- API dev guide: [ubuteco_api/docs/dev-setup.md](../ubuteco_api/docs/dev-setup.md)
+
+## Environment
+
+Create `.env` in repo root:
+
+```env
+API_URL=http://localhost:3000/api
+CABLE_URL=ws://localhost:8080/api/cable
+```
+
+Use your LAN IP instead of `localhost` when testing from another device on the network.
+
+## Run
+
+```bash
+npm install
+npm run dev          # default port from Next (often 3000 if free — check terminal)
+PORT=3001 npm run dev   # recommended if API uses :3000
+```
+
+**Important:** Port 3000 is usually the **Rails API**, not this app. Always read the URL printed by `next dev`.
+
+## Build / lint
+
+```bash
+npm run build
+npm run lint
+```
+
+## After pulling changes
+
+If styles or dark mode look wrong after a merge:
+
+```bash
+rm -rf .next
+npm run dev
+```
+
+## Auth in dev
+
+1. Sign in via `/login` with a user from API seeds or factory.
+2. JWT stored in `localStorage` (`ubuteco_auth_token`, `ubuteco_auth_user`).
+3. Org-scoped roles without `organization_id` redirect to `/forbidden`.
+
+## Real-time (kitchen)
+
+Kitchen queue uses Action Cable → AnyCable. If WebSocket fails, REST polling may still work but updates won't be live — verify `CABLE_URL` and anycable-go is up.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -2,6 +2,8 @@
 
 Companion plans for uButeco React (`ubuteco-react`) — **the only active frontend**. Angular `ubuteco_spa` is abandoned; no SPA migration plans.
 
+**AI assistants:** read [AGENTS.md](../../AGENTS.md) first, then [docs/context/](../context/). New plans: [TEMPLATE.md](./TEMPLATE.md) (full rules in API repo).
+
 Backend work: [`ubuteco_api/docs/plans`](../../../ubuteco_api/docs/plans/README.md).
 
 ## Suggested implementation order
@@ -24,3 +26,11 @@ Backend work: [`ubuteco_api/docs/plans`](../../../ubuteco_api/docs/plans/README.
 Platform hardening (API): [05-platform-hardening](../../../ubuteco_api/docs/plans/05-platform-hardening.md).
 
 **Status legend:** `[ ]` not started · `[~]` in progress · `[x]` done
+
+## Also see
+
+| Doc | Purpose |
+|-----|---------|
+| [context/](../context/) | Frontend architecture and folder map |
+| [dev-setup.md](../dev-setup.md) | Env vars, ports, dev commands |
+| [API plans](../../../ubuteco_api/docs/plans/README.md) | Backend companions |

--- a/docs/plans/TEMPLATE.md
+++ b/docs/plans/TEMPLATE.md
@@ -1,0 +1,37 @@
+# Plan template
+
+Copy this file when adding a new plan. Name: `NN-short-slug.md` (same number in API and React when paired).
+
+```markdown
+# Plan: <Title> (frontend)
+
+**Status:** not started  
+**Project:** ubuteco-react  
+**Backend:** [link to ubuteco_api plan]  
+**Branch:** `feature/<slug>`  
+**Priority:** P0 | P1 | P2
+
+---
+
+## Goal
+
+One paragraph.
+
+---
+
+## Phase 1 — …
+
+- [ ] Task
+
+---
+
+## Definition of done
+
+- [ ] …
+```
+
+See full template and rules in [ubuteco_api/docs/plans/TEMPLATE.md](../../../ubuteco_api/docs/plans/TEMPLATE.md).
+
+## Status legend
+
+`[ ]` not started · `[~]` in progress · `[x]` done


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` with stack, branching rules, and frontend conventions for AI assistants
- Add `docs/context/` (architecture overview and frontend folder map)
- Add `docs/dev-setup.md` and plan template; link from `docs/plans/README.md` and root README

## Test plan
- [ ] Review `AGENTS.md` and context docs on GitHub
- [ ] Verify cross-links to `ubuteco_api` companion docs resolve correctly
- [ ] Confirm docs-only change (no app code)


Made with [Cursor](https://cursor.com)