### PR TITLE
feat(users): staff admin UI with list, CRUD, and role-based access

### DIFF
--- a/docs/plans/07-users-ui.md
+++ b/docs/plans/07-users-ui.md
@@ -1,11 +1,10 @@
 # Plan: Users admin UI
 
-**Status:** not started  
+**Status:** in progress  
 **Project:** ubuteco-react  
 **Backend:** [10-users-admin-api](../../../ubuteco_api/docs/plans/10-users-admin-api.md), existing `UsersController`  
-**Priority:** P1  
-**Depends on:** [01-multi-tenant](../../../ubuteco_api/docs/plans/01-multi-tenant.md), [10-users-admin-api](../../../ubuteco_api/docs/plans/10-users-admin-api.md)  
-**Estimated effort:** 1.5–2 sprints
+**Branch:** `feature/users-ui`  
+**Priority:** P1
 
 ---
 
@@ -26,49 +25,49 @@ Full **staff user management** for org admins: list, search, create, edit roles,
 
 ## Phase 1 — Access
 
-- [ ] `canManageUsers(user)` — ADMIN (and SUPER_ADMIN for platform list later)
-- [ ] Hide `/users` from kitchen, waiter (unless product wants waiter read-only — default: admin only)
-- [ ] Route guard + sidebar filter
+- [x] `canManageUsers(user)` — ADMIN (and SUPER_ADMIN for platform list later)
+- [x] Hide `/users` from kitchen, waiter (unless product wants waiter read-only — default: admin only)
+- [x] Route guard + sidebar filter
 
 ---
 
 ## Phase 2 — Users list
 
-- [ ] Search input → API index with `q` param (Searchkick)
-- [ ] Table: name, email, role, created_at, actions
-- [ ] Pagination (Pagy headers from API — match existing list pages pattern e.g. beers)
-- [ ] Empty state
+- [x] Search input → API index with `q` param (Searchkick)
+- [x] Table: name, email, role, created_at, actions
+- [x] Pagination (Pagy headers from API — match existing list pages pattern e.g. beers)
+- [x] Empty state
 
 ---
 
 ## Phase 3 — Create user
 
-- [ ] `/users/new` — name, email, password, role select
-- [ ] Role options: KITCHEN, WAITER, CASH_REGISTER, ADMIN (not SUPER_ADMIN)
-- [ ] POST create; success → list or show
+- [x] `/users/new` — name, email, password, role select
+- [x] Role options: KITCHEN, WAITER, CASH_REGISTER, ADMIN (not SUPER_ADMIN)
+- [x] POST create; success → list or show
 
 ---
 
 ## Phase 4 — Edit user
 
-- [ ] `/users/[id]/edit` — name, email, role, optional password reset
-- [ ] Cannot edit users outside org (API 403)
+- [x] `/users/[id]/edit` — name, email, role, optional password reset
+- [x] Cannot edit users outside org (API 403)
 - [ ] Admin cannot edit self role to remove last admin (if API guard exists)
 
 ---
 
 ## Phase 5 — Delete user (admin action)
 
-- [ ] Delete button on edit row — confirm dialog
-- [ ] **Admin deletes staff** (e.g. remove kitchen user) — distinct from self-delete in settings
-- [ ] Calls `DELETE /users/:id`; handle 403/errors
+- [x] Delete button on edit row — confirm dialog
+- [x] **Admin deletes staff** (e.g. remove kitchen user) — distinct from self-delete in settings
+- [x] Calls `DELETE /users/:id`; handle 403/errors
 
 ---
 
 ## Phase 6 — Redux / services
 
-- [ ] `usersSlice` + thunks (mirror `beers` or `makers` pattern) OR thin page-level fetch
-- [ ] `usersService` — index, show, create, update, destroy
+- [x] `usersSlice` + thunks (mirror `beers` or `makers` pattern) OR thin page-level fetch
+- [x] `usersService` — index, show, create, update, destroy
 
 ---
 
@@ -82,9 +81,9 @@ Full **staff user management** for org admins: list, search, create, edit roles,
 
 ## Definition of done
 
-- [ ] Admin can CRUD staff in their organization
-- [ ] Search and pagination work
-- [ ] Placeholder page removed
+- [x] Admin can CRUD staff in their organization
+- [x] Search and pagination work
+- [x] Placeholder page removed
 
 ---
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -30,7 +30,7 @@ When a plan gets an issue, add `**GitHub:** owner/repo#NN` to the plan header (s
 | 1 | [Multi-tenant](./01-multi-tenant.md) | in progress | P0 | [API](../../../ubuteco_api/docs/plans/01-multi-tenant.md) |
 | 8 | [Settings — account deletion](./08-settings-account-deletion.md) | not started | P1 | [10-users-admin-api](../../../ubuteco_api/docs/plans/10-users-admin-api.md) |
 | 6 | [Organizations UI](./06-organizations-ui.md) | not started | P1 | Organizations API + [02](../../../ubuteco_api/docs/plans/02-locale-and-currency.md) |
-| 7 | [Users admin UI](./07-users-ui.md) | not started | P1 | [10-users-admin-api](../../../ubuteco_api/docs/plans/10-users-admin-api.md) |
+| 7 | [Users admin UI](./07-users-ui.md) | in progress | P1 | [10-users-admin-api](../../../ubuteco_api/docs/plans/10-users-admin-api.md) |
 | 5 | [Testing](./05-testing.md) | not started | P1 | [08-api-contract-ci](../../../ubuteco_api/docs/plans/08-api-contract-and-ci.md) |
 | 2 | [Locale & currency](./02-locale-and-currency.md) | completed | P1 | [API](../../../ubuteco_api/docs/plans/02-locale-and-currency.md) |
 | 4 | [Organization dashboard](./04-organization-dashboard.md) | not started | P1 | [API](../../../ubuteco_api/docs/plans/04-organization-dashboard.md) |

--- a/src/app/_components/AuthGuard.tsx
+++ b/src/app/_components/AuthGuard.tsx
@@ -5,7 +5,9 @@ import {usePathname, useRouter} from "next/navigation";
 import {getAuthToken} from "@/app/_lib/auth-storage";
 import {isAuthPublicPath} from "@/app/_lib/auth-routes";
 import {
+  canManageUsers,
   hasOrganization,
+  isAdminOnlyPath,
   isKitchenAllowedPath,
   isKitchenStaff,
   isOperationalMutationPath,
@@ -49,6 +51,11 @@ export default function AuthGuard({children}: {children: ReactNode}) {
 
     if (user && isKitchenStaff(user) && !isKitchenAllowedPath(pathname)) {
       router.replace("/kitchen");
+      return;
+    }
+
+    if (user && isAdminOnlyPath(pathname) && !canManageUsers(user)) {
+      router.replace("/");
     }
   }, [ready, pathname, router, authStatus, canMutateOperationalData, user]);
 

--- a/src/app/_lib/auth-roles.ts
+++ b/src/app/_lib/auth-roles.ts
@@ -43,6 +43,22 @@ export function isKitchenStaff(user: User | null | undefined): boolean {
   return getRoleName(user) === "KITCHEN";
 }
 
+export function isAdmin(user: User | null | undefined): boolean {
+  return getRoleName(user) === "ADMIN";
+}
+
+/** Org staff user management (list, create, edit, delete). */
+export function canManageUsers(user: User | null | undefined): boolean {
+  return isAdmin(user);
+}
+
+/** Paths restricted to org admins (staff user management). */
+const ADMIN_ONLY_PATH = /^\/users(\/|$)/;
+
+export function isAdminOnlyPath(pathname: string): boolean {
+  return ADMIN_ONLY_PATH.test(pathname);
+}
+
 /** Paths kitchen-only users may use (queue + account). */
 const KITCHEN_ALLOWED_PATH = /^\/(kitchen|settings)(\/|$)/;
 

--- a/src/app/_lib/i18n/messages/en.ts
+++ b/src/app/_lib/i18n/messages/en.ts
@@ -381,6 +381,43 @@ const en: MessageCatalog = {
       orderDeleted: "Order deleted",
     },
   },
+  users: {
+    title: "Users",
+    list: {
+      title: "Staff",
+      name: "Name",
+      email: "Email",
+      role: "Role",
+      createdAt: "Created",
+      edit: "Edit",
+      empty: "No staff users yet. Add team members who can access the app.",
+    },
+    form: {
+      newTitle: "New staff user",
+      editTitle: "Edit staff user",
+      name: "Name",
+      email: "Email",
+      role: "Role",
+      password: "Password",
+      selectRole: "Select a role…",
+      createSubmit: "Create user",
+      updateSubmit: "Save changes",
+      deleteUser: "Delete user",
+    },
+    roles: {
+      ADMIN: "Admin",
+      KITCHEN: "Kitchen",
+      WAITER: "Waiter",
+      CASH_REGISTER: "Cash register",
+    },
+    confirm: {
+      delete: {
+        title: "Delete user",
+        message: "Remove {name} from your organization? This cannot be undone.",
+        confirm: "Delete",
+      },
+    },
+  },
 };
 
 export default en;

--- a/src/app/_lib/i18n/messages/pt-BR.ts
+++ b/src/app/_lib/i18n/messages/pt-BR.ts
@@ -383,6 +383,43 @@ const ptBR: MessageCatalog = {
       orderDeleted: "Pedido excluído",
     },
   },
+  users: {
+    title: "Usuários",
+    list: {
+      title: "Equipe",
+      name: "Nome",
+      email: "E-mail",
+      role: "Função",
+      createdAt: "Criado em",
+      edit: "Editar",
+      empty: "Nenhum usuário da equipe ainda. Adicione quem pode acessar o app.",
+    },
+    form: {
+      newTitle: "Novo usuário da equipe",
+      editTitle: "Editar usuário da equipe",
+      name: "Nome",
+      email: "E-mail",
+      role: "Função",
+      password: "Senha",
+      selectRole: "Selecione uma função…",
+      createSubmit: "Criar usuário",
+      updateSubmit: "Salvar alterações",
+      deleteUser: "Excluir usuário",
+    },
+    roles: {
+      ADMIN: "Administrador",
+      KITCHEN: "Cozinha",
+      WAITER: "Garçom",
+      CASH_REGISTER: "Caixa",
+    },
+    confirm: {
+      delete: {
+        title: "Excluir usuário",
+        message: "Remover {name} da organização? Esta ação não pode ser desfeita.",
+        confirm: "Excluir",
+      },
+    },
+  },
 };
 
 export default ptBR;

--- a/src/app/_lib/i18n/messages/types.ts
+++ b/src/app/_lib/i18n/messages/types.ts
@@ -361,6 +361,39 @@ export type MessageCatalog = {
       orderDeleted: string;
     };
   };
+  users: {
+    title: string;
+    list: {
+      title: string;
+      name: string;
+      email: string;
+      role: string;
+      createdAt: string;
+      edit: string;
+      empty: string;
+    };
+    form: {
+      newTitle: string;
+      editTitle: string;
+      name: string;
+      email: string;
+      role: string;
+      password: string;
+      selectRole: string;
+      createSubmit: string;
+      updateSubmit: string;
+      deleteUser: string;
+    };
+    roles: {
+      ADMIN: string;
+      KITCHEN: string;
+      WAITER: string;
+      CASH_REGISTER: string;
+    };
+    confirm: {
+      delete: ConfirmMessages;
+    };
+  };
 };
 
 type JoinKeys<P extends string, K extends string> = P extends "" ? K : `${P}.${K}`;

--- a/src/app/_lib/nav-config.test.ts
+++ b/src/app/_lib/nav-config.test.ts
@@ -30,4 +30,20 @@ describe("getVisibleNavGroups", () => {
     const links = groups.flatMap((group) => group.items.map((item) => item.link));
     expect(links).toContain("/organizations");
   });
+
+  it("hides users for non-admin roles", () => {
+    for (const role of ["WAITER", "KITCHEN", "CASH_REGISTER", "SUPER_ADMIN"]) {
+      const links = getVisibleNavGroups(userWithRole(role)).flatMap((group) =>
+        group.items.map((item) => item.link)
+      );
+      expect(links).not.toContain("/users");
+    }
+  });
+
+  it("shows users for org admin", () => {
+    const links = getVisibleNavGroups(userWithRole("ADMIN")).flatMap((group) =>
+      group.items.map((item) => item.link)
+    );
+    expect(links).toContain("/users");
+  });
 });

--- a/src/app/_lib/nav-config.ts
+++ b/src/app/_lib/nav-config.ts
@@ -15,7 +15,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import type {TranslationKey} from "@/app/_lib/i18n";
 import {User} from "@/app/_types";
-import {canAccessKitchen, isKitchenStaff, isSuperAdmin} from "@/app/_lib/auth-roles";
+import {canAccessKitchen, canManageUsers, isKitchenStaff, isSuperAdmin} from "@/app/_lib/auth-roles";
 
 export type NavItem = {
   labelKey: TranslationKey;
@@ -23,6 +23,7 @@ export type NavItem = {
   link: string;
   kitchen?: boolean;
   superAdminOnly?: boolean;
+  adminOnly?: boolean;
 };
 
 export type NavGroup = {
@@ -56,7 +57,7 @@ export const NAV_GROUPS: NavGroup[] = [
   {
     labelKey: "nav.groups.administration",
     items: [
-      {labelKey: "nav.users", icon: faUsers, link: "/users"},
+      {labelKey: "nav.users", icon: faUsers, link: "/users", adminOnly: true},
       {labelKey: "nav.settings", icon: faGear, link: "/settings"},
     ],
   },
@@ -70,6 +71,7 @@ export const NAV_GROUPS: NavGroup[] = [
 
 function isItemVisible(item: NavItem, user: User | null | undefined): boolean {
   if (item.superAdminOnly && !isSuperAdmin(user)) return false;
+  if (item.adminOnly && !canManageUsers(user)) return false;
   if (item.kitchen && !canAccessKitchen(user)) return false;
   return true;
 }

--- a/src/app/_services/roles.service.ts
+++ b/src/app/_services/roles.service.ts
@@ -1,0 +1,10 @@
+import {Role} from "@/app/_types";
+import {apiFetch} from "@/app/_services/api-fetch";
+
+async function fetchAll(): Promise<Role[]> {
+  return await apiFetch<Role[]>("v1/roles");
+}
+
+export const rolesService = {
+  fetchAll,
+};

--- a/src/app/_services/users.service.ts
+++ b/src/app/_services/users.service.ts
@@ -1,25 +1,41 @@
-import {ProfileUpdatePayload, User} from "@/app/_types";
-import {apiFetch} from "@/app/_services/api-fetch";
+import {
+  PaginatedResponse,
+  ProfileUpdatePayload,
+  User,
+  UserCreatePayload,
+  UserUpdatePayload,
+} from "@/app/_types";
+import {apiFetch, apiFetchPaginated} from "@/app/_services/api-fetch";
 
-async function index(): Promise<User[]> {
-  return await apiFetch<User[]>('v1/users');
+export type FetchUsersParams = {
+  search?: string;
+  page?: number;
+};
+
+async function fetchAll(params: FetchUsersParams = {}): Promise<PaginatedResponse<User>> {
+  const {search = "", page = 1} = params;
+  const qs = new URLSearchParams();
+  if (search) qs.set("q", search);
+  if (page > 1) qs.set("page", String(page));
+  const query = qs.toString() ? `?${qs.toString()}` : "";
+  return await apiFetchPaginated<User>(`v1/users${query}`);
 }
 
 async function show(id: number): Promise<User> {
   return await apiFetch<User>(`v1/users/${id}`);
 }
 
-async function create(data: User): Promise<User> {
-  return await apiFetch<User>('v1/users', {
+async function create(data: UserCreatePayload): Promise<User> {
+  return await apiFetch<User>("v1/users", {
     body: JSON.stringify(data),
-    method: 'POST'
+    method: "POST",
   });
 }
 
-async function update(id: number, data: User | ProfileUpdatePayload): Promise<User> {
+async function update(id: number, data: UserUpdatePayload | ProfileUpdatePayload): Promise<User> {
   return await apiFetch<User>(`v1/users/${id}`, {
     body: JSON.stringify(data),
-    method: 'PATCH'
+    method: "PUT",
   });
 }
 
@@ -28,14 +44,14 @@ async function updateProfile(id: number, data: ProfileUpdatePayload): Promise<Us
 }
 
 async function destroy(id: number): Promise<void> {
-  return await apiFetch<void>(`v1/users/${id}`, {method: 'DELETE'});
+  return await apiFetch<void>(`v1/users/${id}`, {method: "DELETE"});
 }
 
 export const usersService = {
+  fetchAll,
+  show,
+  create,
   update,
   updateProfile,
-  create,
-  index,
-  show,
   destroy,
-}
+};

--- a/src/app/_store/features/users/usersSlice.ts
+++ b/src/app/_store/features/users/usersSlice.ts
@@ -1,0 +1,126 @@
+import {ApiMetaData, PaginatedResponse, User} from "@/app/_types";
+import {createSlice} from "@reduxjs/toolkit";
+import {usersThunks} from "./usersThunks";
+
+interface UsersState {
+  users: User[];
+  loading: boolean;
+  errors?: string[];
+  searchTerm: string;
+  page: number;
+  meta: ApiMetaData;
+}
+
+const initialState: UsersState = {
+  users: [],
+  loading: false,
+  errors: undefined,
+  searchTerm: "",
+  page: 1,
+  meta: {
+    count: 0,
+    last: 0,
+    page: 1,
+    pages: 1,
+    previous: null,
+  },
+};
+
+const usersSlice = createSlice({
+  name: "users",
+  initialState,
+  reducers: {
+    setSearchTerm(state, action) {
+      state.searchTerm = action.payload;
+      state.page = 1;
+    },
+    setPage(state, action) {
+      state.page = action.payload;
+    },
+  },
+  extraReducers: (builder) => {
+    builder.addAsyncThunk(usersThunks.fetchAll, {
+      pending: (state) => {
+        state.loading = true;
+        state.errors = undefined;
+      },
+      fulfilled: (state, action) => {
+        state.loading = false;
+        const {meta, data, append} = action.payload as PaginatedResponse<User> & {append: boolean};
+        state.meta = meta;
+        state.page = meta.page;
+        state.users = append ? [...state.users, ...data] : data;
+      },
+      rejected: (state, action) => {
+        state.loading = false;
+        state.errors = action.payload as string[];
+      },
+    });
+    builder.addAsyncThunk(usersThunks.fetchById, {
+      pending: (state) => {
+        state.loading = true;
+      },
+      fulfilled: (state, action) => {
+        state.loading = false;
+        const existing = state.users.find((user) => user.id === action.payload.id);
+        if (existing) {
+          Object.assign(existing, action.payload);
+        } else {
+          state.users.push(action.payload);
+        }
+      },
+      rejected: (state, action) => {
+        state.loading = false;
+        state.errors = action.payload as string[];
+      },
+    });
+    builder.addAsyncThunk(usersThunks.create, {
+      pending: (state) => {
+        state.loading = true;
+        state.errors = undefined;
+      },
+      fulfilled: (state, action) => {
+        state.loading = false;
+        state.users.unshift(action.payload);
+      },
+      rejected: (state, action) => {
+        state.loading = false;
+        state.errors = action.payload as string[];
+      },
+    });
+    builder.addAsyncThunk(usersThunks.update, {
+      pending: (state) => {
+        state.loading = true;
+        state.errors = undefined;
+      },
+      fulfilled: (state, action) => {
+        state.loading = false;
+        const index = state.users.findIndex((user) => user.id === action.payload.id);
+        if (index !== -1) {
+          state.users[index] = action.payload;
+        }
+      },
+      rejected: (state, action) => {
+        state.loading = false;
+        state.errors = action.payload as string[];
+      },
+    });
+    builder.addAsyncThunk(usersThunks.delete, {
+      pending: (state) => {
+        state.loading = true;
+        state.errors = undefined;
+      },
+      fulfilled: (state, action) => {
+        state.loading = false;
+        state.users = state.users.filter((user) => user.id !== action.payload);
+      },
+      rejected: (state, action) => {
+        state.loading = false;
+        state.errors = action.payload as string[];
+      },
+    });
+  },
+});
+
+export const {setSearchTerm, setPage} = usersSlice.actions;
+export default usersSlice.reducer;

--- a/src/app/_store/features/users/usersThunks.ts
+++ b/src/app/_store/features/users/usersThunks.ts
@@ -1,0 +1,90 @@
+import {createAsyncThunk} from "@reduxjs/toolkit";
+import {User, UserCreatePayload, UserUpdatePayload} from "@/app/_types";
+import {ApiError} from "@/app/_services/api-fetch";
+import {FetchUsersParams, usersService} from "@/app/_services/users.service";
+
+export type FetchUsersResult = {
+  data: User[];
+  meta: Awaited<ReturnType<typeof usersService.fetchAll>>["meta"];
+  append: boolean;
+};
+
+const fetchAll = createAsyncThunk(
+  "users/fetchAll",
+  async (params: FetchUsersParams & {append?: boolean} = {}, {rejectWithValue}) => {
+    try {
+      const result = await usersService.fetchAll(params);
+      return {...result, append: params.append ?? false};
+    } catch (err) {
+      if (err instanceof ApiError) {
+        return rejectWithValue(err.data);
+      }
+      return rejectWithValue(["Could not load users"]);
+    }
+  }
+);
+
+const fetchById = createAsyncThunk(
+  "users/fetchById",
+  async (id: number, {rejectWithValue}) => {
+    try {
+      return await usersService.show(id);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        return rejectWithValue(err.data);
+      }
+      return rejectWithValue(["Could not load user"]);
+    }
+  }
+);
+
+const createUser = createAsyncThunk(
+  "users/create",
+  async (data: UserCreatePayload, {rejectWithValue}) => {
+    try {
+      return await usersService.create(data);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        return rejectWithValue(err.data);
+      }
+      return rejectWithValue(["Could not create user"]);
+    }
+  }
+);
+
+const updateUser = createAsyncThunk(
+  "users/update",
+  async ({id, data}: {id: number; data: UserUpdatePayload}, {rejectWithValue}) => {
+    try {
+      return await usersService.update(id, data);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        return rejectWithValue(err.data);
+      }
+      return rejectWithValue(["Could not update user"]);
+    }
+  }
+);
+
+const deleteUser = createAsyncThunk(
+  "users/delete",
+  async (id: number, {rejectWithValue}) => {
+    try {
+      await usersService.destroy(id);
+      return id;
+    } catch (err) {
+      if (err instanceof ApiError) {
+        return rejectWithValue(err.data);
+      }
+      return rejectWithValue(["Could not delete user"]);
+    }
+  }
+);
+
+export const usersThunks = {
+  fetchAll,
+  fetchById,
+  create: createUser,
+  update: updateUser,
+  delete: deleteUser,
+};

--- a/src/app/_store/index.ts
+++ b/src/app/_store/index.ts
@@ -12,11 +12,14 @@ import authReducer from "@/app/_store/features/auth/authSlice";
 import ordersReducer from "@/app/_store/features/orders/ordersSlice";
 import kitchenReducer from "@/app/_store/features/kitchen/kitchenSlice";
 
+import usersReducer from "@/app/_store/features/users/usersSlice";
+
 export const store = configureStore({
   reducer: {
     auth: authReducer,
     orders: ordersReducer,
     kitchen: kitchenReducer,
+    users: usersReducer,
     beers: beersReducer,
     beerStyles: beerStylesReducer,
     dishes: dishesReducer,

--- a/src/app/_types/user.ts
+++ b/src/app/_types/user.ts
@@ -30,6 +30,20 @@ export type ProfileUpdatePayload = {
   password?: string;
 };
 
+export type UserCreatePayload = {
+  name: string;
+  email: string;
+  password: string;
+  role_id: number;
+};
+
+export type UserUpdatePayload = {
+  name?: string;
+  email?: string;
+  password?: string;
+  role_id?: number;
+};
+
 export interface SignUpPayload {
   user: {
     email: string;

--- a/src/app/users/[id]/edit/page.tsx
+++ b/src/app/users/[id]/edit/page.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import {useEffect} from "react";
+import {useParams, useRouter} from "next/navigation";
+import {useSelector} from "react-redux";
+import {Loading} from "@/app/_components";
+import {RootState} from "@/app/_store";
+import {useAppDispatch} from "@/app/_store/hooks";
+import {usersThunks} from "@/app/_store/features/users/usersThunks";
+import {UserForm} from "@/app/users/components";
+import {useConfirm} from "@/app/_hooks/useConfirm";
+import {useTranslations} from "@/app/_hooks/useTranslations";
+import {ConfirmDialog} from "@/app/_components/ConfirmDialog";
+
+export default function Page() {
+  const {id} = useParams<{id: string}>();
+  const userId = Number(id);
+  const dispatch = useAppDispatch();
+  const router = useRouter();
+  const t = useTranslations();
+  const {confirm, confirmDialogProps} = useConfirm();
+  const user = useSelector((state: RootState) =>
+    state.users.users.find((entry) => entry.id === userId)
+  );
+  const {loading, errors} = useSelector((state: RootState) => state.users);
+
+  useEffect(() => {
+    if (userId) {
+      dispatch(usersThunks.fetchById(userId));
+    }
+  }, [dispatch, userId]);
+
+  async function handleUpdate(payload: {
+    name: string;
+    email: string;
+    password?: string;
+    role_id: number;
+  }) {
+    try {
+      await dispatch(usersThunks.update({id: userId, data: payload})).unwrap();
+      router.push("/users");
+    } catch {
+      // errors in slice
+    }
+  }
+
+  async function handleDelete() {
+    const ok = await confirm({
+      title: t("users.confirm.delete.title"),
+      message: t("users.confirm.delete.message", {name: user?.name ?? user?.email ?? ""}),
+      confirmLabel: t("users.confirm.delete.confirm"),
+      variant: "danger",
+    });
+    if (!ok) return;
+
+    try {
+      await dispatch(usersThunks.delete(userId)).unwrap();
+      router.push("/users");
+    } catch {
+      // errors in slice
+    }
+  }
+
+  if (loading && !user) return <Loading/>;
+  if (!user) return <h1 className="text-foreground">{t("common.notFound")}</h1>;
+
+  return (
+    <>
+      <UserForm
+        mode="edit"
+        defaultValues={user}
+        onSubmit={handleUpdate}
+        onDelete={handleDelete}
+        deleteLoading={loading}
+        submitLabel={t("users.form.updateSubmit")}
+        loading={loading}
+        errors={errors}
+      />
+      <ConfirmDialog {...confirmDialogProps}/>
+    </>
+  );
+}

--- a/src/app/users/_lib/assignable-roles.test.ts
+++ b/src/app/users/_lib/assignable-roles.test.ts
@@ -1,0 +1,15 @@
+import {describe, expect, it} from "vitest";
+import {filterAssignableRoles} from "@/app/users/_lib/assignable-roles";
+
+describe("filterAssignableRoles", () => {
+  it("returns only staff roles assignable by org admin", () => {
+    const roles = [
+      {id: 1, name: "ADMIN"},
+      {id: 2, name: "WAITER"},
+      {id: 3, name: "SUPER_ADMIN"},
+      {id: 4, name: "CUSTOMER"},
+    ];
+
+    expect(filterAssignableRoles(roles).map((role) => role.name)).toEqual(["ADMIN", "WAITER"]);
+  });
+});

--- a/src/app/users/_lib/assignable-roles.ts
+++ b/src/app/users/_lib/assignable-roles.ts
@@ -1,0 +1,17 @@
+import {Role} from "@/app/_types";
+
+/** Staff roles an org admin may assign (excludes SUPER_ADMIN and CUSTOMER). */
+export const ASSIGNABLE_ROLE_NAMES = [
+  "KITCHEN",
+  "WAITER",
+  "CASH_REGISTER",
+  "ADMIN",
+] as const;
+
+export type AssignableRoleName = (typeof ASSIGNABLE_ROLE_NAMES)[number];
+
+export function filterAssignableRoles(roles: Role[]): Role[] {
+  return roles.filter(
+    (role) => role.name != null && ASSIGNABLE_ROLE_NAMES.includes(role.name as AssignableRoleName)
+  );
+}

--- a/src/app/users/components/UserForm.tsx
+++ b/src/app/users/components/UserForm.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import {FormEvent, useEffect, useState} from "react";
+import {Role, User} from "@/app/_types";
+import {Buttons, Card, FormErrors, Input, Label, Select} from "@/app/_components";
+import {rolesService} from "@/app/_services/roles.service";
+import {useTranslations} from "@/app/_hooks/useTranslations";
+import {filterAssignableRoles} from "@/app/users/_lib/assignable-roles";
+import type {TranslationKey} from "@/app/_lib/i18n";
+
+type Props = {
+  defaultValues?: Partial<User>;
+  errors?: string[];
+  loading?: boolean;
+  submitLabel: string;
+  mode: "create" | "edit";
+  onSubmit: (payload: {
+    name: string;
+    email: string;
+    password?: string;
+    role_id: number;
+  }) => void | Promise<void>;
+  onDelete?: () => void | Promise<void>;
+  deleteLoading?: boolean;
+};
+
+function roleLabelKey(roleName: string): TranslationKey {
+  return `users.roles.${roleName}` as TranslationKey;
+}
+
+export function UserForm({
+  defaultValues,
+  errors,
+  loading = false,
+  submitLabel,
+  mode,
+  onSubmit,
+  onDelete,
+  deleteLoading = false,
+}: Props) {
+  const t = useTranslations();
+  const [roles, setRoles] = useState<Role[]>([]);
+  const [rolesLoading, setRolesLoading] = useState(true);
+  const [name, setName] = useState(defaultValues?.name ?? "");
+  const [email, setEmail] = useState(defaultValues?.email ?? "");
+  const [password, setPassword] = useState("");
+  const [roleId, setRoleId] = useState(String(defaultValues?.role_id ?? defaultValues?.role?.id ?? ""));
+
+  useEffect(() => {
+    void rolesService.fetchAll().then((data) => {
+      setRoles(filterAssignableRoles(data));
+      setRolesLoading(false);
+    });
+  }, []);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    const payload = {
+      name: name.trim(),
+      email: email.trim(),
+      role_id: Number(roleId),
+      ...(password.trim() ? {password: password.trim()} : {}),
+    };
+    await onSubmit(payload);
+  };
+
+  return (
+    <Card
+      title={mode === "create" ? t("users.form.newTitle") : t("users.form.editTitle")}
+      className="mx-auto max-w-2xl"
+    >
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <FormErrors errors={errors}/>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Label label={t("users.form.name")}>
+            <Input name="name" value={name} onChange={(e) => setName(e.target.value)} required/>
+          </Label>
+
+          <Label label={t("users.form.email")}>
+            <Input
+              name="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </Label>
+        </div>
+
+        <Label label={t("users.form.role")}>
+          <Select
+            name="role_id"
+            value={roleId}
+            onChange={setRoleId}
+            disabled={rolesLoading}
+          >
+            <option value="">{rolesLoading ? t("common.loading") : t("users.form.selectRole")}</option>
+            {roles.map((role) => (
+              <option key={role.id} value={String(role.id)}>
+                {t(roleLabelKey(role.name ?? ""))}
+              </option>
+            ))}
+          </Select>
+        </Label>
+
+        <Label
+          label={
+            mode === "create"
+              ? t("users.form.password")
+              : `${t("users.form.password")} (${t("common.optional")})`
+          }
+        >
+          <Input
+            name="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required={mode === "create"}
+          />
+        </Label>
+
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          {mode === "edit" && onDelete ? (
+            <Buttons type="button" variant="danger" onClick={onDelete} loading={deleteLoading}>
+              {t("users.form.deleteUser")}
+            </Buttons>
+          ) : (
+            <span/>
+          )}
+          <Buttons type="submit" loading={loading}>
+            {submitLabel}
+          </Buttons>
+        </div>
+      </form>
+    </Card>
+  );
+}

--- a/src/app/users/components/UsersTable.tsx
+++ b/src/app/users/components/UsersTable.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import Link from "next/link";
+import {User} from "@/app/_types";
+import {Buttons} from "@/app/_components";
+import {useMoneyFormat} from "@/app/_hooks/useMoneyFormat";
+import {useTranslations} from "@/app/_hooks/useTranslations";
+import type {TranslationKey} from "@/app/_lib/i18n";
+
+type Props = {
+  users: User[];
+};
+
+function roleLabelKey(roleName: string): TranslationKey {
+  return `users.roles.${roleName}` as TranslationKey;
+}
+
+export function UsersTable({users}: Props) {
+  const t = useTranslations();
+  const {formatDate} = useMoneyFormat();
+
+  if (users.length === 0) {
+    return (
+      <p className="rounded-xl border border-dashed border-border px-4 py-8 text-center text-sm text-muted">
+        {t("users.list.empty")}
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-border">
+      <table className="min-w-full divide-y divide-border text-sm">
+        <thead className="bg-surface-muted">
+          <tr>
+            <th className="px-4 py-3 text-left font-medium text-muted">{t("users.list.name")}</th>
+            <th className="px-4 py-3 text-left font-medium text-muted">{t("users.list.email")}</th>
+            <th className="px-4 py-3 text-left font-medium text-muted">{t("users.list.role")}</th>
+            <th className="px-4 py-3 text-left font-medium text-muted">{t("users.list.createdAt")}</th>
+            <th className="w-24 px-4 py-3"/>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border bg-surface">
+          {users.map((user) => (
+            <tr key={user.id}>
+              <td className="px-4 py-3 font-medium text-foreground">{user.name ?? "—"}</td>
+              <td className="px-4 py-3 text-muted">{user.email ?? "—"}</td>
+              <td className="px-4 py-3 text-muted">
+                {user.role?.name ? t(roleLabelKey(user.role.name)) : "—"}
+              </td>
+              <td className="px-4 py-3 text-muted">
+                {user.created_at ? formatDate(user.created_at) : "—"}
+              </td>
+              <td className="px-4 py-3 text-right">
+                <Link href={`/users/${user.id}/edit`}>
+                  <Buttons type="button" variant="outline" size="sm">
+                    {t("users.list.edit")}
+                  </Buttons>
+                </Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/app/users/components/index.ts
+++ b/src/app/users/components/index.ts
@@ -1,0 +1,2 @@
+export {UserForm} from "./UserForm";
+export {UsersTable} from "./UsersTable";

--- a/src/app/users/new/page.tsx
+++ b/src/app/users/new/page.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import {useRouter} from "next/navigation";
+import {useSelector} from "react-redux";
+import {RootState} from "@/app/_store";
+import {useAppDispatch} from "@/app/_store/hooks";
+import {usersThunks} from "@/app/_store/features/users/usersThunks";
+import {UserForm} from "@/app/users/components";
+import {useTranslations} from "@/app/_hooks/useTranslations";
+
+export default function Page() {
+  const {loading, errors} = useSelector((state: RootState) => state.users);
+  const dispatch = useAppDispatch();
+  const router = useRouter();
+  const t = useTranslations();
+
+  async function handleCreate(payload: {
+    name: string;
+    email: string;
+    password?: string;
+    role_id: number;
+  }) {
+    if (!payload.password) return;
+    try {
+      await dispatch(
+        usersThunks.create({
+          name: payload.name,
+          email: payload.email,
+          password: payload.password,
+          role_id: payload.role_id,
+        })
+      ).unwrap();
+      router.push("/users");
+    } catch {
+      // errors in slice
+    }
+  }
+
+  return (
+    <UserForm
+      mode="create"
+      onSubmit={handleCreate}
+      submitLabel={t("users.form.createSubmit")}
+      loading={loading}
+      errors={errors}
+    />
+  );
+}

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -1,8 +1,53 @@
 "use client";
 
+import {useEffect} from "react";
+import dynamic from "next/dynamic";
+import {Card, FormErrors, Loading, Toolbar} from "@/app/_components";
+import {Pagination} from "@/app/_components/Pagination";
+import {UsersTable} from "@/app/users/components";
+import {useAppDispatch, useAppSelector} from "@/app/_store/hooks";
+import {RootState} from "@/app/_store";
+import {usersThunks} from "@/app/_store/features/users/usersThunks";
+import {setPage, setSearchTerm} from "@/app/_store/features/users/usersSlice";
 import {useTranslations} from "@/app/_hooks/useTranslations";
 
-export default function Page() {
+function Page() {
+  const dispatch = useAppDispatch();
   const t = useTranslations();
-  return <h1>{t("catalog.usersPlaceholder")}</h1>;
+  const {users, loading, searchTerm, page, meta, errors} = useAppSelector(
+    (state: RootState) => state.users
+  );
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      dispatch(usersThunks.fetchAll({search: searchTerm, page: 1, append: false}));
+    }, 500);
+    return () => clearTimeout(timeout);
+  }, [searchTerm, dispatch]);
+
+  const loadMore = () => {
+    const nextPage = page + 1;
+    dispatch(setPage(nextPage));
+    dispatch(usersThunks.fetchAll({search: searchTerm, page: nextPage, append: true}));
+  };
+
+  return (
+    <div className="space-y-6">
+      <Toolbar
+        title={t("users.title")}
+        newUrl="/users/new"
+        searchValue={searchTerm}
+        onSearch={(e) => dispatch(setSearchTerm(e.target.value))}
+      />
+
+      <FormErrors errors={errors}/>
+
+      <Card title={t("users.list.title")} className="hover:translate-y-0">
+        {loading && users.length === 0 ? <Loading/> : <UsersTable users={users}/>}
+        <Pagination meta={meta} loading={loading} onLoadMore={loadMore}/>
+      </Card>
+    </div>
+  );
 }
+
+export default dynamic(() => Promise.resolve(Page), {ssr: false});


### PR DESCRIPTION
## Summary

- Add org-admin user management at `/users`: Searchkick search, paginated table, create/edit forms, and delete with confirmation.
- Restrict nav and routes to `ADMIN` via `canManageUsers` / `isAdminOnlyPath`; wire `usersSlice`, thunks, and extended `usersService` + `rolesService`.
- i18n for users UI (en + pt-BR); unit tests for nav visibility and assignable roles; plan 07 phases 1–6 marked done.

## Test plan

- [ ] Log in as ADMIN — sidebar shows Users; `/users` loads list with search and pagination
- [ ] Log in as WAITER/KITCHEN — Users nav hidden; direct `/users` redirects away
- [ ] Create user at `/users/new` with role KITCHEN/WAITER/CASH_REGISTER/ADMIN — appears in list
- [ ] Edit user at `/users/[id]/edit` — name, email, role update; delete with confirm removes user
- [ ] Run `npm test` — `nav-config.test.ts` and `assignable-roles.test.ts` pass


Made with [Cursor](https://cursor.com)