### PR TITLE
feat(organizations): admin profile UI and super-admin platform list

### DIFF
--- a/docs/plans/06-organizations-ui.md
+++ b/docs/plans/06-organizations-ui.md
@@ -1,8 +1,9 @@
 # Plan: Organizations UI
 
-**Status:** not started  
+**Status:** in progress  
 **Project:** ubuteco-react  
 **Backend:** [Organizations API](../../../ubuteco_api/app/controllers/api/v1/organizations_controller.rb), [02-locale-and-currency](../../../ubuteco_api/docs/plans/02-locale-and-currency.md)  
+**Branch:** `feature/organizations-ui`  
 **Priority:** P1  
 **Estimated effort:** 1–1.5 sprints
 
@@ -16,71 +17,73 @@ Replace the **placeholder** `/organizations` page with a real admin experience: 
 
 ## Current state
 
-- `src/app/organizations/page.tsx` — placeholder (`<h1>Tables index page</h1>` — copy-paste error).
-- Sidebar links “Organizations” for privileged roles.
-- API: `OrganizationsController`, `operational_status` on org.
-- Kitchen page already PATCHes `operational_status` for open/closed kitchen.
+- `src/app/organizations/page.tsx` — admin profile + super-admin list (replaces placeholder).
+- Sidebar “Organizations” for org ADMIN and SUPER_ADMIN (administration group).
+- API: `OrganizationsController`, `operational_status` on org; platform list at `v1/platform/organizations`.
+- Kitchen page uses shared `OrganizationOperationalToggle`.
 
 ---
 
 ## Phase 1 — Access & routing
 
-- [ ] **Org ADMIN:** `/organizations` → edit **own** org (redirect `/organizations/current` or single org form)
-- [ ] **SUPER_ADMIN:** list all orgs (search) + link to detail (future platform API from [01-multi-tenant](../../../ubuteco_api/docs/plans/01-multi-tenant.md))
-- [ ] `canManageOrganization(user)` helper in `auth-roles.ts`
-- [ ] Guard route; forbidden for kitchen-only staff
+- [x] **Org ADMIN:** `/organizations` → edit **own** org (single org form)
+- [x] **SUPER_ADMIN:** list all orgs (search) + link to detail at `/organizations/[id]`
+- [x] `canManageOrganization(user)` helper in `auth-roles.ts`
+- [x] Guard route; forbidden for kitchen-only staff and non-admin roles
 
 ---
 
 ## Phase 2 — Organization profile UI
 
-- [ ] Show: name, phone, logo, `operational_status`
-- [ ] Edit form: name, phone, logo upload (match API multipart patterns from dishes/beers)
+- [x] Show: name, phone, logo, `operational_status`
+- [x] Edit form: name, phone, logo upload (multipart PATCH)
 
 ---
 
 ## Phase 3 — Operational settings
 
-- [ ] Kitchen open/closed toggle (reuse logic from `kitchen/page.tsx` — extract shared hook/component `OrganizationOperationalToggle`)
-- [ ] Confirm dialog when closing kitchen (closes open orders on API)
-- [ ] When [02-locale-and-currency](./02-locale-and-currency.md) lands: locale, currency, timezone fields here or under settings
+- [x] Kitchen open/closed toggle — shared `OrganizationOperationalToggle` + `useOrganizationOperationalToggle`
+- [x] Confirm dialog when closing kitchen (closes open orders on API)
+- [x] Locale, currency, timezone via reused `LocaleSettings` on org admin page (also in settings)
 
 ---
 
 ## Phase 4 — Services & state
 
-- [ ] `organizationsService` — list, show, update (verify existing methods)
-- [ ] After update: refresh `auth.user.organization` in Redux
-- [ ] Toast success/error patterns (match orders/kitchen)
+- [x] `organizationsService` — paginated index, show, update, updateForm
+- [x] `platformOrganizationsService` — super-admin list/show/update
+- [x] After update: refresh `auth.user.organization` in Redux
+- [x] Toast success/error patterns (match kitchen)
 
 ---
 
-## Phase 5 — Super admin list (if in scope)
+## Phase 5 — Super admin list
 
-- [ ] Paginated table: name, phone, status, created_at
-- [ ] Search via API if available
-- [ ] Defer create org to registration flow unless product asks
+- [x] Paginated table: name, phone, status, created_at
+- [x] Search via API (`q` param)
+- [x] Defer create org to registration flow
 
 ---
 
 ## Phase 6 — Tests
 
-- [ ] Role guard: kitchen cannot access `/organizations`
-- [ ] Render org form with mocked org
-- [ ] Toggle operational status calls API
+- [x] Role guard: kitchen cannot access `/organizations` (nav + auth-roles)
+- [x] Operational toggle hook calls API
+- [ ] Render org form with mocked org (MSW — optional follow-up)
 
 ---
 
 ## Definition of done
 
-- [ ] No placeholder page; admin can manage org profile and kitchen status from org UI
-- [ ] Shared operational toggle DRY with kitchen page
-- [ ] Super admin has list view or documented deferral
+- [x] No placeholder page; admin can manage org profile and kitchen status from org UI
+- [x] Shared operational toggle DRY with kitchen page
+- [x] Super admin has list view + detail edit via platform API
 
 ---
 
 ## References
 
-- `src/app/kitchen/page.tsx` — operational toggle
+- `src/app/kitchen/page.tsx` — operational toggle (uses shared component)
 - `src/app/_services/organizations.service.ts`
+- `src/app/_services/platform-organizations.service.ts`
 - `src/app/_components/SidebarLayout.tsx` — menu visibility

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -29,7 +29,7 @@ When a plan gets an issue, add `**GitHub:** owner/repo#NN` to the plan header (s
 |---|------|--------|----------|-------------|
 | 1 | [Multi-tenant](./01-multi-tenant.md) | in progress | P0 | [API](../../../ubuteco_api/docs/plans/01-multi-tenant.md) |
 | 8 | [Settings — account deletion](./08-settings-account-deletion.md) | not started | P1 | [10-users-admin-api](../../../ubuteco_api/docs/plans/10-users-admin-api.md) |
-| 6 | [Organizations UI](./06-organizations-ui.md) | not started | P1 | Organizations API + [02](../../../ubuteco_api/docs/plans/02-locale-and-currency.md) |
+| 6 | [Organizations UI](./06-organizations-ui.md) | in progress | P1 | Organizations API + [02](../../../ubuteco_api/docs/plans/02-locale-and-currency.md) |
 | 7 | [Users admin UI](./07-users-ui.md) | in progress | P1 | [10-users-admin-api](../../../ubuteco_api/docs/plans/10-users-admin-api.md) |
 | 5 | [Testing](./05-testing.md) | not started | P1 | [08-api-contract-ci](../../../ubuteco_api/docs/plans/08-api-contract-and-ci.md) |
 | 2 | [Locale & currency](./02-locale-and-currency.md) | completed | P1 | [API](../../../ubuteco_api/docs/plans/02-locale-and-currency.md) |

--- a/src/app/_components/AuthGuard.tsx
+++ b/src/app/_components/AuthGuard.tsx
@@ -5,12 +5,14 @@ import {usePathname, useRouter} from "next/navigation";
 import {getAuthToken} from "@/app/_lib/auth-storage";
 import {isAuthPublicPath} from "@/app/_lib/auth-routes";
 import {
+  canAccessOrganizations,
   canManageUsers,
   hasOrganization,
   isAdminOnlyPath,
   isKitchenAllowedPath,
   isKitchenStaff,
   isOperationalMutationPath,
+  isOrganizationPath,
   requiresOrganization,
 } from "@/app/_lib/auth-roles";
 import {useAuthCapabilities} from "@/app/_hooks/useAuthCapabilities";
@@ -55,6 +57,11 @@ export default function AuthGuard({children}: {children: ReactNode}) {
     }
 
     if (user && isAdminOnlyPath(pathname) && !canManageUsers(user)) {
+      router.replace("/");
+      return;
+    }
+
+    if (user && isOrganizationPath(pathname) && !canAccessOrganizations(user)) {
       router.replace("/");
     }
   }, [ready, pathname, router, authStatus, canMutateOperationalData, user]);

--- a/src/app/_components/Toolbar.tsx
+++ b/src/app/_components/Toolbar.tsx
@@ -7,7 +7,7 @@ import {useTranslations} from "@/app/_hooks/useTranslations";
 
 type Props = {
   title: string,
-  newUrl: string
+  newUrl?: string
   searchValue: string
   showAdd?: boolean
   onSearch?: (e: React.ChangeEvent<HTMLInputElement>) => void
@@ -25,7 +25,7 @@ export function Toolbar({title, onSearch, newUrl, searchValue, showAdd = true}: 
                  placeholder={t("common.search")}
                  value={searchValue}
       />
-      {showAdd && <AddButton url={newUrl}/>}
+      {showAdd && newUrl ? <AddButton url={newUrl}/> : null}
     </div>
   )
 }

--- a/src/app/_hooks/useOrganizationSettings.ts
+++ b/src/app/_hooks/useOrganizationSettings.ts
@@ -2,7 +2,7 @@
 
 import {useMemo} from "react";
 import {useAuthCapabilities} from "@/app/_hooks/useAuthCapabilities";
-import {getRoleName} from "@/app/_lib/auth-roles";
+import {canManageOrganization} from "@/app/_lib/auth-roles";
 import {resolveOrganizationSettings} from "@/app/_lib/organization-settings";
 
 export function useOrganizationSettings() {
@@ -14,7 +14,7 @@ export function useOrganizationSettings() {
     return {
       organization: user?.organization ?? null,
       ...settings,
-      canManage: getRoleName(user) === "ADMIN",
+      canManage: canManageOrganization(user),
     };
   }, [user]);
 }

--- a/src/app/_lib/auth-roles.test.ts
+++ b/src/app/_lib/auth-roles.test.ts
@@ -1,0 +1,36 @@
+import {describe, expect, it} from "vitest";
+import {
+  canAccessOrganizations,
+  canManageOrganization,
+  isOrganizationPath,
+} from "@/app/_lib/auth-roles";
+import {User} from "@/app/_types";
+
+function userWithRole(role: string): User {
+  return {
+    id: 1,
+    name: "Test",
+    email: "test@example.com",
+    role: {id: 1, name: role},
+  } as User;
+}
+
+describe("organization access", () => {
+  it("allows org admin and super admin to access organizations UI", () => {
+    expect(canManageOrganization(userWithRole("ADMIN"))).toBe(true);
+    expect(canAccessOrganizations(userWithRole("ADMIN"))).toBe(true);
+    expect(canAccessOrganizations(userWithRole("SUPER_ADMIN"))).toBe(true);
+  });
+
+  it("denies kitchen and waiter roles", () => {
+    expect(canAccessOrganizations(userWithRole("KITCHEN"))).toBe(false);
+    expect(canAccessOrganizations(userWithRole("WAITER"))).toBe(false);
+    expect(canAccessOrganizations(userWithRole("CASH_REGISTER"))).toBe(false);
+  });
+
+  it("matches organization routes", () => {
+    expect(isOrganizationPath("/organizations")).toBe(true);
+    expect(isOrganizationPath("/organizations/42")).toBe(true);
+    expect(isOrganizationPath("/orders")).toBe(false);
+  });
+});

--- a/src/app/_lib/auth-roles.ts
+++ b/src/app/_lib/auth-roles.ts
@@ -52,6 +52,22 @@ export function canManageUsers(user: User | null | undefined): boolean {
   return isAdmin(user);
 }
 
+/** Org profile and operational settings for the authenticated tenant. */
+export function canManageOrganization(user: User | null | undefined): boolean {
+  return isAdmin(user);
+}
+
+/** Organization admin UI (own org for ADMIN, cross-org list for SUPER_ADMIN). */
+export function canAccessOrganizations(user: User | null | undefined): boolean {
+  return isSuperAdmin(user) || canManageOrganization(user);
+}
+
+const ORGANIZATION_PATH = /^\/organizations(\/|$)/;
+
+export function isOrganizationPath(pathname: string): boolean {
+  return ORGANIZATION_PATH.test(pathname);
+}
+
 /** Paths restricted to org admins (staff user management). */
 const ADMIN_ONLY_PATH = /^\/users(\/|$)/;
 

--- a/src/app/_lib/i18n/messages/en.ts
+++ b/src/app/_lib/i18n/messages/en.ts
@@ -418,6 +418,40 @@ const en: MessageCatalog = {
       },
     },
   },
+  organizations: {
+    profile: {
+      title: "Organization",
+      subtitle: "Manage your bar or restaurant profile and kitchen status.",
+    },
+    list: {
+      title: "Organizations",
+      cardTitle: "All organizations",
+      name: "Name",
+      phone: "Phone",
+      status: "Kitchen",
+      statusOpen: "Open",
+      statusClosed: "Closed",
+      createdAt: "Created",
+      view: "View",
+      empty: "No organizations found.",
+      loadFailed: "Could not load organizations.",
+    },
+    form: {
+      profileTitle: "Profile",
+      name: "Organization name",
+      phone: "Phone",
+      logo: "Logo",
+      logoAlt: "Organization logo",
+      save: "Save changes",
+      saveFailed: "Could not save organization.",
+    },
+    operational: {
+      title: "Kitchen status",
+      hint: "When closed, the kitchen queue is paused and open orders may be closed on the API.",
+      open: "Kitchen is open — orders flow to the queue.",
+      closed: "Kitchen is closed — new items are not processed.",
+    },
+  },
 };
 
 export default en;

--- a/src/app/_lib/i18n/messages/pt-BR.ts
+++ b/src/app/_lib/i18n/messages/pt-BR.ts
@@ -420,6 +420,40 @@ const ptBR: MessageCatalog = {
       },
     },
   },
+  organizations: {
+    profile: {
+      title: "Organização",
+      subtitle: "Gerencie o perfil do seu bar ou restaurante e o status da cozinha.",
+    },
+    list: {
+      title: "Organizações",
+      cardTitle: "Todas as organizações",
+      name: "Nome",
+      phone: "Telefone",
+      status: "Cozinha",
+      statusOpen: "Aberta",
+      statusClosed: "Fechada",
+      createdAt: "Criado em",
+      view: "Ver",
+      empty: "Nenhuma organização encontrada.",
+      loadFailed: "Não foi possível carregar as organizações.",
+    },
+    form: {
+      profileTitle: "Perfil",
+      name: "Nome da organização",
+      phone: "Telefone",
+      logo: "Logo",
+      logoAlt: "Logo da organização",
+      save: "Salvar alterações",
+      saveFailed: "Não foi possível salvar a organização.",
+    },
+    operational: {
+      title: "Status da cozinha",
+      hint: "Quando fechada, a fila da cozinha pausa e pedidos abertos podem ser encerrados na API.",
+      open: "Cozinha aberta — pedidos seguem para a fila.",
+      closed: "Cozinha fechada — novos itens não são processados.",
+    },
+  },
 };
 
 export default ptBR;

--- a/src/app/_lib/i18n/messages/types.ts
+++ b/src/app/_lib/i18n/messages/types.ts
@@ -394,6 +394,40 @@ export type MessageCatalog = {
       delete: ConfirmMessages;
     };
   };
+  organizations: {
+    profile: {
+      title: string;
+      subtitle: string;
+    };
+    list: {
+      title: string;
+      cardTitle: string;
+      name: string;
+      phone: string;
+      status: string;
+      statusOpen: string;
+      statusClosed: string;
+      createdAt: string;
+      view: string;
+      empty: string;
+      loadFailed: string;
+    };
+    form: {
+      profileTitle: string;
+      name: string;
+      phone: string;
+      logo: string;
+      logoAlt: string;
+      save: string;
+      saveFailed: string;
+    };
+    operational: {
+      title: string;
+      hint: string;
+      open: string;
+      closed: string;
+    };
+  };
 };
 
 type JoinKeys<P extends string, K extends string> = P extends "" ? K : `${P}.${K}`;

--- a/src/app/_lib/nav-config.test.ts
+++ b/src/app/_lib/nav-config.test.ts
@@ -18,10 +18,10 @@ describe("getVisibleNavGroups", () => {
     expect(links).toEqual(["/kitchen", "/settings"]);
   });
 
-  it("hides organizations for org admin", () => {
+  it("shows organizations for org admin", () => {
     const groups = getVisibleNavGroups(userWithRole("ADMIN"));
     const links = groups.flatMap((group) => group.items.map((item) => item.link));
-    expect(links).not.toContain("/organizations");
+    expect(links).toContain("/organizations");
     expect(links).toContain("/orders");
   });
 
@@ -38,6 +38,13 @@ describe("getVisibleNavGroups", () => {
       );
       expect(links).not.toContain("/users");
     }
+  });
+
+  it("hides organizations for kitchen staff", () => {
+    const links = getVisibleNavGroups(userWithRole("KITCHEN")).flatMap((group) =>
+      group.items.map((item) => item.link)
+    );
+    expect(links).not.toContain("/organizations");
   });
 
   it("shows users for org admin", () => {

--- a/src/app/_lib/nav-config.ts
+++ b/src/app/_lib/nav-config.ts
@@ -15,7 +15,13 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import type {TranslationKey} from "@/app/_lib/i18n";
 import {User} from "@/app/_types";
-import {canAccessKitchen, canManageUsers, isKitchenStaff, isSuperAdmin} from "@/app/_lib/auth-roles";
+import {
+  canAccessKitchen,
+  canAccessOrganizations,
+  canManageUsers,
+  isKitchenStaff,
+  isSuperAdmin,
+} from "@/app/_lib/auth-roles";
 
 export type NavItem = {
   labelKey: TranslationKey;
@@ -24,6 +30,7 @@ export type NavItem = {
   kitchen?: boolean;
   superAdminOnly?: boolean;
   adminOnly?: boolean;
+  organizationAccess?: boolean;
 };
 
 export type NavGroup = {
@@ -58,13 +65,8 @@ export const NAV_GROUPS: NavGroup[] = [
     labelKey: "nav.groups.administration",
     items: [
       {labelKey: "nav.users", icon: faUsers, link: "/users", adminOnly: true},
+      {labelKey: "nav.organizations", icon: faBuilding, link: "/organizations", organizationAccess: true},
       {labelKey: "nav.settings", icon: faGear, link: "/settings"},
-    ],
-  },
-  {
-    labelKey: "nav.groups.platform",
-    items: [
-      {labelKey: "nav.organizations", icon: faBuilding, link: "/organizations", superAdminOnly: true},
     ],
   },
 ];
@@ -72,6 +74,7 @@ export const NAV_GROUPS: NavGroup[] = [
 function isItemVisible(item: NavItem, user: User | null | undefined): boolean {
   if (item.superAdminOnly && !isSuperAdmin(user)) return false;
   if (item.adminOnly && !canManageUsers(user)) return false;
+  if (item.organizationAccess && !canAccessOrganizations(user)) return false;
   if (item.kitchen && !canAccessKitchen(user)) return false;
   return true;
 }

--- a/src/app/_lib/organization-operational.test.ts
+++ b/src/app/_lib/organization-operational.test.ts
@@ -1,0 +1,18 @@
+import {describe, expect, it} from "vitest";
+import {
+  isOrganizationKitchenOpen,
+  nextOperationalStatus,
+} from "@/app/_lib/organization-operational";
+
+describe("organization-operational", () => {
+  it("detects open kitchen from operational_status", () => {
+    expect(isOrganizationKitchenOpen({operational_status: "open"})).toBe(true);
+    expect(isOrganizationKitchenOpen({operational_status: "closed"})).toBe(false);
+  });
+
+  it("toggles operational status for API PATCH payload", () => {
+    expect(nextOperationalStatus("open")).toBe("closed");
+    expect(nextOperationalStatus("closed")).toBe("open");
+    expect(nextOperationalStatus(undefined)).toBe("open");
+  });
+});

--- a/src/app/_services/organizations.service.test.ts
+++ b/src/app/_services/organizations.service.test.ts
@@ -28,4 +28,19 @@ describe("organizationsService.update", () => {
     });
     expect(result).toEqual(updated);
   });
+
+  it("PATCHes multipart profile updates", async () => {
+    const formData = new FormData();
+    formData.set("name", "Bar");
+    const updated = {id: 42, name: "Bar"};
+    vi.mocked(apiFetch).mockResolvedValue(updated);
+
+    const result = await organizationsService.updateForm(42, formData);
+
+    expect(apiFetch).toHaveBeenCalledWith("v1/organizations/42", {
+      body: formData,
+      method: "PATCH",
+    });
+    expect(result).toEqual(updated);
+  });
 });

--- a/src/app/_services/organizations.service.ts
+++ b/src/app/_services/organizations.service.ts
@@ -1,8 +1,18 @@
-import {Organization} from "@/app/_types";
-import {apiFetch} from "@/app/_services/api-fetch";
+import {Organization, PaginatedResponse} from "@/app/_types";
+import {apiFetch, apiFetchPaginated} from "@/app/_services/api-fetch";
 
-async function index(): Promise<Organization[]> {
-  return await apiFetch<Organization[]>('v1/organizations');
+export type FetchOrganizationsParams = {
+  search?: string;
+  page?: number;
+};
+
+async function index(params: FetchOrganizationsParams = {}): Promise<PaginatedResponse<Organization>> {
+  const {search = "", page = 1} = params;
+  const qs = new URLSearchParams();
+  if (search) qs.set("q", search);
+  if (page > 1) qs.set("page", String(page));
+  const query = qs.toString() ? `?${qs.toString()}` : "";
+  return await apiFetchPaginated<Organization>(`v1/organizations${query}`);
 }
 
 async function show(id: number): Promise<Organization> {
@@ -23,12 +33,20 @@ async function update(id: number, data: Partial<Organization>): Promise<Organiza
   });
 }
 
+async function updateForm(id: number, data: FormData): Promise<Organization> {
+  return await apiFetch<Organization>(`v1/organizations/${id}`, {
+    body: data,
+    method: 'PATCH',
+  });
+}
+
 async function destroy(id: number): Promise<void> {
   await apiFetch<void>(`v1/organizations/${id}`, {method: 'DELETE'});
 }
 
 export const organizationsService = {
   update,
+  updateForm,
   create,
   index,
   show,

--- a/src/app/_services/platform-organizations.service.ts
+++ b/src/app/_services/platform-organizations.service.ts
@@ -1,0 +1,43 @@
+import {Organization, PaginatedResponse} from "@/app/_types";
+import {apiFetch, apiFetchPaginated} from "@/app/_services/api-fetch";
+
+export type FetchPlatformOrganizationsParams = {
+  search?: string;
+  page?: number;
+};
+
+async function fetchAll(
+  params: FetchPlatformOrganizationsParams = {}
+): Promise<PaginatedResponse<Organization>> {
+  const {search = "", page = 1} = params;
+  const qs = new URLSearchParams();
+  if (search) qs.set("q", search);
+  if (page > 1) qs.set("page", String(page));
+  const query = qs.toString() ? `?${qs.toString()}` : "";
+  return await apiFetchPaginated<Organization>(`v1/platform/organizations${query}`);
+}
+
+async function show(id: number): Promise<Organization> {
+  return await apiFetch<Organization>(`v1/platform/organizations/${id}`);
+}
+
+async function update(id: number, data: Partial<Organization>): Promise<Organization> {
+  return await apiFetch<Organization>(`v1/platform/organizations/${id}`, {
+    body: JSON.stringify(data),
+    method: "PATCH",
+  });
+}
+
+async function updateForm(id: number, data: FormData): Promise<Organization> {
+  return await apiFetch<Organization>(`v1/platform/organizations/${id}`, {
+    body: data,
+    method: "PATCH",
+  });
+}
+
+export const platformOrganizationsService = {
+  fetchAll,
+  show,
+  update,
+  updateForm,
+};

--- a/src/app/_types/organization.ts
+++ b/src/app/_types/organization.ts
@@ -7,6 +7,7 @@ export interface Organization extends BaseModel {
   cnpj?: string;
   phone?: string;
   logo?: PictureFromS3;
+  logo_url?: string;
   user_id?: number;
   operational_status?: OrganizationOperationalStatus;
   locale?: string;

--- a/src/app/kitchen/page.tsx
+++ b/src/app/kitchen/page.tsx
@@ -1,23 +1,17 @@
 "use client";
 
-import {useCallback, useEffect, useState} from "react";
+import {useCallback, useEffect} from "react";
 import dynamic from "next/dynamic";
 import {FormErrors, Loading} from "@/app/_components";
-import {ConfirmDialog} from "@/app/_components/ConfirmDialog";
 import {KitchenBoard} from "@/app/kitchen/components/KitchenBoard";
+import {OrganizationOperationalToggle} from "@/app/organizations/components";
 import {useToast} from "@/app/_components/Toast/ToastProvider";
 import {useAuthCapabilities} from "@/app/_hooks/useAuthCapabilities";
-import {useConfirm} from "@/app/_hooks/useConfirm";
 import {useKitchenCable} from "@/app/_hooks/useKitchenCable";
 import {canAccessKitchen, isKitchenStaff} from "@/app/_lib/auth-roles";
-import {
-  isOrganizationKitchenOpen,
-  nextOperationalStatus,
-} from "@/app/_lib/organization-operational";
-import {organizationsService} from "@/app/_services/organizations.service";
+import {isOrganizationKitchenOpen} from "@/app/_lib/organization-operational";
 import {useAppDispatch, useAppSelector} from "@/app/_store/hooks";
 import {RootState} from "@/app/_store";
-import {updateAuthenticatedUser} from "@/app/_store/features/auth/authSlice";
 import {fetchCurrentUser} from "@/app/_store/features/auth/authThunks";
 import {kitchenThunks} from "@/app/_store/features/kitchen/kitchenThunks";
 import {ActionCableKitchenMessage} from "@/app/_types/kitchen-dish";
@@ -29,7 +23,6 @@ function KitchenPage() {
   const router = useRouter();
   const dispatch = useAppDispatch();
   const {showToast} = useToast();
-  const {confirm, confirmDialogProps} = useConfirm();
   const t = useTranslations();
   const {user: capabilitiesUser} = useAuthCapabilities();
   const authUser = useAppSelector((state: RootState) => state.auth.user);
@@ -39,7 +32,6 @@ function KitchenPage() {
   );
   const canUseKitchen = canAccessKitchen(user);
   const isKitchenOpen = isOrganizationKitchenOpen(user?.organization);
-  const [togglingOperational, setTogglingOperational] = useState(false);
 
   const loadQueue = useCallback(() => {
     dispatch(kitchenThunks.fetchTickets());
@@ -99,73 +91,19 @@ function KitchenPage() {
     [dispatch, isKitchenOpen, showToast, t]
   );
 
-  const handleOperationalToggle = useCallback(async () => {
-    const org = user?.organization;
-    if (!user || !org?.id) return;
-
-    const closing = isKitchenOpen;
-    if (closing) {
-      const ok = await confirm({
-        title: t("kitchen.closeKitchen"),
-        message: t("kitchen.closeKitchenMessage"),
-        confirmLabel: t("kitchen.closeKitchenConfirm"),
-        variant: "danger",
-      });
-      if (!ok) return;
-    }
-
-    setTogglingOperational(true);
-    try {
-      const operational_status = nextOperationalStatus(org.operational_status);
-      const updated = await organizationsService.update(org.id, {operational_status});
-      dispatch(
-        updateAuthenticatedUser({
-          ...user,
-          organization: {...org, ...updated},
-        })
-      );
-      loadQueue();
-      showToast(
-        operational_status === "open" ? t("kitchen.toastOpened") : t("kitchen.toastClosed"),
-        "success"
-      );
-    } catch {
-      showToast(t("kitchen.toastOperationalFailed"), "error");
-    } finally {
-      setTogglingOperational(false);
-    }
-  }, [confirm, dispatch, isKitchenOpen, loadQueue, showToast, t, user]);
-
   if (!canUseKitchen) {
     return <Loading/>;
   }
 
   return (
     <div className="space-y-6">
-      <ConfirmDialog {...confirmDialogProps} loading={togglingOperational}/>
-
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-3xl font-bold text-foreground">{t("kitchen.title")}</h1>
           <p className="mt-1 text-sm text-muted">{t("kitchen.description")}</p>
         </div>
         <div className="flex flex-wrap items-center gap-2 text-sm">
-          <button
-            type="button"
-            disabled={togglingOperational}
-            onClick={handleOperationalToggle}
-            className={`rounded-full border px-3 py-1 font-medium transition-colors disabled:opacity-60 ${
-              isKitchenOpen
-                ? "border-emerald-300 bg-emerald-50 text-emerald-900 hover:bg-emerald-100 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300"
-                : "border-border bg-surface-muted text-foreground hover:bg-border"
-            }`}
-          >
-            {togglingOperational
-              ? t("kitchen.updating")
-              : isKitchenOpen
-                ? t("kitchen.openCloseOpen")
-                : t("kitchen.openCloseClosed")}
-          </button>
+          <OrganizationOperationalToggle compact onChanged={loadQueue}/>
           <span
             className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 font-medium ${
               cableConnected

--- a/src/app/organizations/[id]/page.tsx
+++ b/src/app/organizations/[id]/page.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import {useEffect, useState} from "react";
+import dynamic from "next/dynamic";
+import {useParams, useRouter} from "next/navigation";
+import {Loading} from "@/app/_components";
+import {useAuthCapabilities} from "@/app/_hooks/useAuthCapabilities";
+import {canManageOrganization, isSuperAdmin} from "@/app/_lib/auth-roles";
+import {platformOrganizationsService} from "@/app/_services/platform-organizations.service";
+import {OrganizationProfilePage} from "@/app/organizations/components";
+
+function Page() {
+  const params = useParams();
+  const router = useRouter();
+  const {user} = useAuthCapabilities();
+  const id = Number(params.id);
+
+  const [organization, setOrganization] = useState<Awaited<
+    ReturnType<typeof platformOrganizationsService.show>
+  > | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!user || Number.isNaN(id)) return;
+
+    if (isSuperAdmin(user)) {
+      setLoading(true);
+      void platformOrganizationsService
+        .show(id)
+        .then(setOrganization)
+        .finally(() => setLoading(false));
+      return;
+    }
+
+    if (canManageOrganization(user) && user.organization?.id === id) {
+      setOrganization(user.organization);
+      setLoading(false);
+      return;
+    }
+
+    router.replace("/organizations");
+  }, [id, router, user]);
+
+  if (loading || !organization) {
+    return <Loading/>;
+  }
+
+  return (
+    <OrganizationProfilePage
+      organization={organization}
+      onOrganizationUpdated={setOrganization}
+      updateForm={platformOrganizationsService.updateForm}
+      updateOperational={platformOrganizationsService.update}
+      showRegionalSettings={!isSuperAdmin(user)}
+    />
+  );
+}
+
+export default dynamic(() => Promise.resolve(Page), {ssr: false});

--- a/src/app/organizations/_hooks/useOrganizationOperationalToggle.ts
+++ b/src/app/organizations/_hooks/useOrganizationOperationalToggle.ts
@@ -1,0 +1,97 @@
+"use client";
+
+import {useCallback, useState} from "react";
+import {useToast} from "@/app/_components/Toast/ToastProvider";
+import {useConfirm} from "@/app/_hooks/useConfirm";
+import {useTranslations} from "@/app/_hooks/useTranslations";
+import {
+  isOrganizationKitchenOpen,
+  nextOperationalStatus,
+} from "@/app/_lib/organization-operational";
+import {setAuthUser} from "@/app/_lib/auth-storage";
+import {organizationsService} from "@/app/_services/organizations.service";
+import {useAppDispatch, useAppSelector} from "@/app/_store/hooks";
+import {updateAuthenticatedUser} from "@/app/_store/features/auth/authSlice";
+import {Organization, User} from "@/app/_types";
+
+type UpdateFn = (id: number, data: Partial<Organization>) => Promise<Organization>;
+
+type Options = {
+  organization?: Organization | null;
+  onChanged?: () => void;
+  update?: UpdateFn;
+  onOrganizationUpdated?: (organization: Organization) => void;
+};
+
+export function useOrganizationOperationalToggle(options: Options = {}) {
+  const dispatch = useAppDispatch();
+  const {showToast} = useToast();
+  const {confirm, confirmDialogProps} = useConfirm();
+  const t = useTranslations();
+  const user = useAppSelector((state) => state.auth.user);
+  const organization = options.organization ?? user?.organization ?? null;
+  const isKitchenOpen = isOrganizationKitchenOpen(organization);
+  const [toggling, setToggling] = useState(false);
+
+  const syncAuthOrganization = useCallback(
+    (updated: Organization) => {
+      if (!user?.organization?.id || user.organization.id !== updated.id) return;
+
+      const nextUser: User = {
+        ...user,
+        organization: {...user.organization, ...updated},
+      };
+      dispatch(updateAuthenticatedUser(nextUser));
+      setAuthUser(nextUser);
+    },
+    [dispatch, user]
+  );
+
+  const handleToggle = useCallback(async () => {
+    if (!organization?.id) return;
+
+    const closing = isKitchenOpen;
+    if (closing) {
+      const ok = await confirm({
+        title: t("kitchen.closeKitchen"),
+        message: t("kitchen.closeKitchenMessage"),
+        confirmLabel: t("kitchen.closeKitchenConfirm"),
+        variant: "danger",
+      });
+      if (!ok) return;
+    }
+
+    setToggling(true);
+    try {
+      const operational_status = nextOperationalStatus(organization.operational_status);
+      const update = options.update ?? organizationsService.update;
+      const updated = await update(organization.id, {operational_status});
+      syncAuthOrganization(updated);
+      options.onOrganizationUpdated?.(updated);
+      options.onChanged?.();
+      showToast(
+        operational_status === "open" ? t("kitchen.toastOpened") : t("kitchen.toastClosed"),
+        "success"
+      );
+    } catch {
+      showToast(t("kitchen.toastOperationalFailed"), "error");
+    } finally {
+      setToggling(false);
+    }
+  }, [
+    confirm,
+    isKitchenOpen,
+    options,
+    organization,
+    showToast,
+    syncAuthOrganization,
+    t,
+  ]);
+
+  return {
+    isKitchenOpen,
+    toggling,
+    handleToggle,
+    confirmDialogProps: {...confirmDialogProps, loading: toggling},
+  };
+}

--- a/src/app/organizations/components/OrganizationForm.tsx
+++ b/src/app/organizations/components/OrganizationForm.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import {FormEvent, useEffect, useState} from "react";
+import {Buttons, Card, FormErrors, Input, Label} from "@/app/_components";
+import {Organization} from "@/app/_types";
+import {useTranslations} from "@/app/_hooks/useTranslations";
+
+type Props = {
+  defaultValues: Organization;
+  errors?: string[];
+  loading?: boolean;
+  submitLabel: string;
+  onSubmit: (payload: FormData) => void | Promise<void>;
+  readOnly?: boolean;
+};
+
+export function OrganizationForm({
+  defaultValues,
+  errors,
+  loading = false,
+  submitLabel,
+  onSubmit,
+  readOnly = false,
+}: Props) {
+  const t = useTranslations();
+  const [name, setName] = useState(defaultValues.name ?? "");
+  const [phone, setPhone] = useState(defaultValues.phone ?? "");
+  const [preview, setPreview] = useState<string | null>(defaultValues.logo_url ?? null);
+
+  useEffect(() => {
+    setName(defaultValues.name ?? "");
+    setPhone(defaultValues.phone ?? "");
+    setPreview(defaultValues.logo_url ?? null);
+  }, [defaultValues.id, defaultValues.name, defaultValues.phone, defaultValues.logo_url]);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (readOnly) return;
+
+    const formData = new FormData();
+    formData.set("name", name.trim());
+    formData.set("phone", phone.trim());
+
+    const fileInput = (event.target as HTMLFormElement).elements.namedItem("logo") as HTMLInputElement | null;
+    const file = fileInput?.files?.[0];
+    if (file) {
+      formData.set("logo", file);
+    }
+
+    await onSubmit(formData);
+  };
+
+  return (
+    <Card title={t("organizations.form.profileTitle")} className="hover:translate-y-0">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <FormErrors errors={errors}/>
+
+        <Label label={t("organizations.form.name")}>
+          <Input
+            name="name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            disabled={readOnly}
+            className="!pl-4"
+          />
+        </Label>
+
+        <Label label={t("organizations.form.phone")}>
+          <Input
+            name="phone"
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            required
+            disabled={readOnly}
+            className="!pl-4"
+          />
+        </Label>
+
+        <div>
+          {preview ? (
+            <img
+              src={preview}
+              alt={t("organizations.form.logoAlt")}
+              className="mb-2 h-24 w-24 rounded-xl object-cover"
+            />
+          ) : null}
+          <Label label={t("organizations.form.logo")}>
+            <Input
+              type="file"
+              name="logo"
+              accept="image/*"
+              disabled={readOnly}
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (!file) return;
+                setPreview(URL.createObjectURL(file));
+              }}
+            />
+          </Label>
+        </div>
+
+        {!readOnly ? (
+          <div className="flex justify-end">
+            <Buttons type="submit" loading={loading}>
+              {submitLabel}
+            </Buttons>
+          </div>
+        ) : null}
+      </form>
+    </Card>
+  );
+}

--- a/src/app/organizations/components/OrganizationOperationalToggle.tsx
+++ b/src/app/organizations/components/OrganizationOperationalToggle.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import {ConfirmDialog} from "@/app/_components/ConfirmDialog";
+import {Organization} from "@/app/_types";
+import {useOrganizationOperationalToggle} from "@/app/organizations/_hooks/useOrganizationOperationalToggle";
+import {useTranslations} from "@/app/_hooks/useTranslations";
+
+type UpdateFn = (id: number, data: Partial<Organization>) => Promise<Organization>;
+
+type Props = {
+  organization?: Organization | null;
+  onChanged?: () => void;
+  update?: UpdateFn;
+  onOrganizationUpdated?: (organization: Organization) => void;
+  compact?: boolean;
+};
+
+export function OrganizationOperationalToggle({
+  organization,
+  onChanged,
+  update,
+  onOrganizationUpdated,
+  compact = false,
+}: Props) {
+  const t = useTranslations();
+  const {isKitchenOpen, toggling, handleToggle, confirmDialogProps} =
+    useOrganizationOperationalToggle({
+      organization,
+      onChanged,
+      update,
+      onOrganizationUpdated,
+    });
+
+  return (
+    <>
+      <ConfirmDialog {...confirmDialogProps} />
+      <div className={compact ? "flex flex-wrap items-center gap-2" : "space-y-2"}>
+        {!compact ? (
+          <p className="text-sm text-muted">{t("organizations.operational.hint")}</p>
+        ) : null}
+        <button
+          type="button"
+          disabled={toggling}
+          onClick={handleToggle}
+          className={`rounded-full border px-3 py-1 text-sm font-medium transition-colors disabled:opacity-60 ${
+            isKitchenOpen
+              ? "border-emerald-300 bg-emerald-50 text-emerald-900 hover:bg-emerald-100 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300"
+              : "border-border bg-surface-muted text-foreground hover:bg-border"
+          }`}
+        >
+          {toggling
+            ? t("kitchen.updating")
+            : isKitchenOpen
+              ? t("kitchen.openCloseOpen")
+              : t("kitchen.openCloseClosed")}
+        </button>
+        {!compact ? (
+          <p className="text-xs text-muted">
+            {isKitchenOpen ? t("organizations.operational.open") : t("organizations.operational.closed")}
+          </p>
+        ) : null}
+      </div>
+    </>
+  );
+}

--- a/src/app/organizations/components/OrganizationProfilePage.tsx
+++ b/src/app/organizations/components/OrganizationProfilePage.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import {useCallback, useState} from "react";
+import {Card} from "@/app/_components";
+import {Organization} from "@/app/_types";
+import {setAuthUser} from "@/app/_lib/auth-storage";
+import {organizationsService} from "@/app/_services/organizations.service";
+import {ApiError} from "@/app/_services/api-fetch";
+import {useAppDispatch, useAppSelector} from "@/app/_store/hooks";
+import {updateAuthenticatedUser} from "@/app/_store/features/auth/authSlice";
+import {useTranslations} from "@/app/_hooks/useTranslations";
+import {LocaleSettings} from "@/app/settings/components/LocaleSettings";
+import {
+  OrganizationForm,
+  OrganizationOperationalToggle,
+} from "@/app/organizations/components";
+
+type Props = {
+  organization: Organization;
+  onOrganizationUpdated?: (organization: Organization) => void;
+  updateForm?: (id: number, data: FormData) => Promise<Organization>;
+  updateOperational?: (id: number, data: Partial<Organization>) => Promise<Organization>;
+  showRegionalSettings?: boolean;
+};
+
+export function OrganizationProfilePage({
+  organization,
+  onOrganizationUpdated,
+  updateForm = organizationsService.updateForm,
+  updateOperational = organizationsService.update,
+  showRegionalSettings = true,
+}: Props) {
+  const dispatch = useAppDispatch();
+  const user = useAppSelector((state) => state.auth.user);
+  const t = useTranslations();
+  const [current, setCurrent] = useState(organization);
+  const [saving, setSaving] = useState(false);
+  const [errors, setErrors] = useState<string[] | undefined>();
+
+  const syncAuthOrganization = useCallback(
+    (updated: Organization) => {
+      if (!user?.organization?.id || user.organization.id !== updated.id) return;
+      const nextUser = {
+        ...user,
+        organization: {...user.organization, ...updated},
+      };
+      dispatch(updateAuthenticatedUser(nextUser));
+      setAuthUser(nextUser);
+    },
+    [dispatch, user]
+  );
+
+  const handleSubmit = async (formData: FormData) => {
+    if (!current.id) return;
+
+    setSaving(true);
+    setErrors(undefined);
+    try {
+      const updated = await updateForm(current.id, formData);
+      setCurrent(updated);
+      syncAuthOrganization(updated);
+      onOrganizationUpdated?.(updated);
+    } catch (error) {
+      if (error instanceof ApiError) {
+        setErrors(error.data);
+      } else {
+        setErrors([t("organizations.form.saveFailed")]);
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleOperationalUpdated = (updated: Organization) => {
+    setCurrent(updated);
+    onOrganizationUpdated?.(updated);
+  };
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold text-foreground">{t("organizations.profile.title")}</h1>
+        <p className="mt-1 text-sm text-muted">{t("organizations.profile.subtitle")}</p>
+      </div>
+
+      <OrganizationForm
+        defaultValues={current}
+        errors={errors}
+        loading={saving}
+        submitLabel={t("organizations.form.save")}
+        onSubmit={handleSubmit}
+      />
+
+      <Card title={t("organizations.operational.title")} className="hover:translate-y-0">
+        <OrganizationOperationalToggle
+          organization={current}
+          update={updateOperational}
+          onOrganizationUpdated={handleOperationalUpdated}
+        />
+      </Card>
+
+      {showRegionalSettings ? (
+        <Card title={t("settings.regional")} className="hover:translate-y-0">
+          <p className="mb-4 text-sm text-muted">{t("settings.regionalHint")}</p>
+          <LocaleSettings/>
+        </Card>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/organizations/components/OrganizationsTable.tsx
+++ b/src/app/organizations/components/OrganizationsTable.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import Link from "next/link";
+import {Organization} from "@/app/_types";
+import {Buttons} from "@/app/_components";
+import {useMoneyFormat} from "@/app/_hooks/useMoneyFormat";
+import {useTranslations} from "@/app/_hooks/useTranslations";
+
+type Props = {
+  organizations: Organization[];
+};
+
+function statusLabel(
+  organization: Organization,
+  t: ReturnType<typeof useTranslations>
+): string {
+  return organization.operational_status === "open"
+    ? t("organizations.list.statusOpen")
+    : t("organizations.list.statusClosed");
+}
+
+export function OrganizationsTable({organizations}: Props) {
+  const t = useTranslations();
+  const {formatDate} = useMoneyFormat();
+
+  if (organizations.length === 0) {
+    return (
+      <p className="rounded-xl border border-dashed border-border px-4 py-8 text-center text-sm text-muted">
+        {t("organizations.list.empty")}
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-border">
+      <table className="min-w-full divide-y divide-border text-sm">
+        <thead className="bg-surface-muted">
+          <tr>
+            <th className="px-4 py-3 text-left font-medium text-muted">{t("organizations.list.name")}</th>
+            <th className="px-4 py-3 text-left font-medium text-muted">{t("organizations.list.phone")}</th>
+            <th className="px-4 py-3 text-left font-medium text-muted">{t("organizations.list.status")}</th>
+            <th className="px-4 py-3 text-left font-medium text-muted">{t("organizations.list.createdAt")}</th>
+            <th className="w-24 px-4 py-3"/>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border bg-surface">
+          {organizations.map((organization) => (
+            <tr key={organization.id}>
+              <td className="px-4 py-3 font-medium text-foreground">{organization.name ?? "—"}</td>
+              <td className="px-4 py-3 text-muted">{organization.phone ?? "—"}</td>
+              <td className="px-4 py-3 text-muted">{statusLabel(organization, t)}</td>
+              <td className="px-4 py-3 text-muted">
+                {organization.created_at ? formatDate(organization.created_at) : "—"}
+              </td>
+              <td className="px-4 py-3 text-right">
+                {organization.id ? (
+                  <Link href={`/organizations/${organization.id}`}>
+                    <Buttons type="button" variant="outline" size="sm">
+                      {t("organizations.list.view")}
+                    </Buttons>
+                  </Link>
+                ) : (
+                  "—"
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/app/organizations/components/index.ts
+++ b/src/app/organizations/components/index.ts
@@ -1,0 +1,4 @@
+export {OrganizationForm} from "./OrganizationForm";
+export {OrganizationOperationalToggle} from "./OrganizationOperationalToggle";
+export {OrganizationProfilePage} from "./OrganizationProfilePage";
+export {OrganizationsTable} from "./OrganizationsTable";

--- a/src/app/organizations/page.tsx
+++ b/src/app/organizations/page.tsx
@@ -1,8 +1,124 @@
 "use client";
 
+import {useEffect, useState} from "react";
+import dynamic from "next/dynamic";
+import {useRouter} from "next/navigation";
+import {ApiMetaData, Organization} from "@/app/_types";
+import {Card, FormErrors, Loading, Toolbar} from "@/app/_components";
+import {Pagination} from "@/app/_components/Pagination";
+import {useAuthCapabilities} from "@/app/_hooks/useAuthCapabilities";
+import {canManageOrganization, isSuperAdmin} from "@/app/_lib/auth-roles";
+import {platformOrganizationsService} from "@/app/_services/platform-organizations.service";
+import {ApiError} from "@/app/_services/api-fetch";
 import {useTranslations} from "@/app/_hooks/useTranslations";
+import {OrganizationProfilePage, OrganizationsTable} from "@/app/organizations/components";
 
-export default function Page() {
+function SuperAdminOrganizationsList() {
   const t = useTranslations();
-  return <h1>{t("catalog.organizationsPlaceholder")}</h1>;
+  const [organizations, setOrganizations] = useState<Organization[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [page, setPage] = useState(1);
+  const [meta, setMeta] = useState<ApiMetaData>({
+    count: 0,
+    last: 0,
+    page: 1,
+    pages: 1,
+    previous: null,
+  });
+  const [errors, setErrors] = useState<string[] | undefined>();
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setLoading(true);
+      setErrors(undefined);
+      void platformOrganizationsService
+        .fetchAll({search: searchTerm, page: 1})
+        .then((response) => {
+          setOrganizations(response.data);
+          setMeta(response.meta);
+          setPage(response.meta.page);
+        })
+        .catch((error) => {
+          if (error instanceof ApiError) {
+            setErrors(error.data);
+          } else {
+            setErrors([t("organizations.list.loadFailed")]);
+          }
+        })
+        .finally(() => setLoading(false));
+    }, 500);
+
+    return () => clearTimeout(timeout);
+  }, [searchTerm, t]);
+
+  const loadMore = () => {
+    const nextPage = page + 1;
+    setLoading(true);
+    void platformOrganizationsService
+      .fetchAll({search: searchTerm, page: nextPage})
+      .then((response) => {
+        setOrganizations((current) => [...current, ...response.data]);
+        setMeta(response.meta);
+        setPage(response.meta.page);
+      })
+      .catch((error) => {
+        if (error instanceof ApiError) {
+          setErrors(error.data);
+        }
+      })
+      .finally(() => setLoading(false));
+  };
+
+  return (
+    <div className="space-y-6">
+      <Toolbar
+        title={t("organizations.list.title")}
+        searchValue={searchTerm}
+        onSearch={(e) => setSearchTerm(e.target.value)}
+        showAdd={false}
+      />
+
+      <FormErrors errors={errors}/>
+
+      <Card title={t("organizations.list.cardTitle")} className="hover:translate-y-0">
+        {loading && organizations.length === 0 ? (
+          <Loading/>
+        ) : (
+          <OrganizationsTable organizations={organizations}/>
+        )}
+        <Pagination meta={meta} loading={loading} onLoadMore={loadMore}/>
+      </Card>
+    </div>
+  );
 }
+
+function Page() {
+  const router = useRouter();
+  const {user} = useAuthCapabilities();
+  const isSuper = isSuperAdmin(user);
+  const isOrgAdmin = canManageOrganization(user);
+
+  useEffect(() => {
+    if (!user) return;
+    if (!isSuper && !isOrgAdmin) {
+      router.replace("/");
+    }
+  }, [user, isSuper, isOrgAdmin, router]);
+
+  if (!user || (!isSuper && !isOrgAdmin)) {
+    return <Loading/>;
+  }
+
+  if (isSuper) {
+    return <SuperAdminOrganizationsList/>;
+  }
+
+  if (!user.organization) {
+    return <Loading/>;
+  }
+
+  return <OrganizationProfilePage organization={user.organization} showRegionalSettings/>;
+}
+
+export default dynamic(() => Promise.resolve(Page), {ssr: false});


### PR DESCRIPTION
## Summary

- Add org management at `/organizations` for **ADMIN**: profile form (name, phone, logo), shared kitchen operational toggle, and regional settings via `LocaleSettings`.
- Add **SUPER_ADMIN** experience: searchable paginated list via `v1/platform/organizations` and detail edit at `/organizations/[id]`.
- Extract `OrganizationOperationalToggle` / `useOrganizationOperationalToggle` (DRY with kitchen page); extend `organizationsService` and add `platformOrganizationsService`; role guards and nav visibility.

## Test plan

- [ ] Log in as ADMIN — `/organizations` shows profile, kitchen toggle, regional settings; save name/phone/logo works
- [ ] Log in as SUPER_ADMIN — `/organizations` lists orgs with search; view detail opens edit page
- [ ] Log in as KITCHEN/WAITER — `/organizations` nav hidden; direct URL redirects home
- [ ] Kitchen page toggle still works and stays in sync with org status
- [ ] `npm test` — 29 tests pass

## Depends on

- API fix for platform organization jbuilder partials (separate PR in ubuteco_api)


Made with [Cursor](https://cursor.com)