### PR TITLE
fix: show API validation messages instead of error codes

### DIFF
--- a/src/app/_lib/normalize-errors.test.ts
+++ b/src/app/_lib/normalize-errors.test.ts
@@ -1,0 +1,48 @@
+import {describe, expect, it} from "vitest";
+import {normalizeErrors} from "@/app/_lib/normalize-errors";
+
+describe("normalizeErrors", () => {
+  it("extracts messages from structured API errors response", () => {
+    const messages = normalizeErrors({
+      errors: [
+        {code: "validation_error", field: "name", message: "Name não pode ficar em branco"},
+        {code: "validation_error", field: "maker", message: "Maker é obrigatório(a)"},
+      ],
+    });
+
+    expect(messages).toEqual([
+      "Name não pode ficar em branco",
+      "Maker é obrigatório(a)",
+    ]);
+  });
+
+  it("extracts messages from a bare errors array", () => {
+    const messages = normalizeErrors([
+      {code: "insufficient_stock", message: "Insufficient stock"},
+    ]);
+
+    expect(messages).toEqual(["Insufficient stock"]);
+  });
+
+  it("supports legacy string arrays", () => {
+    expect(normalizeErrors(["Email has already been taken", "Password is too short"])).toEqual([
+      "Email has already been taken",
+      "Password is too short",
+    ]);
+  });
+
+  it("supports nested Devise-style field errors", () => {
+    const messages = normalizeErrors({
+      user: {
+        email: ["can't be blank"],
+      },
+    });
+
+    expect(messages).toEqual(["can't be blank"]);
+  });
+
+  it("returns empty array for nullish input", () => {
+    expect(normalizeErrors(null)).toEqual([]);
+    expect(normalizeErrors(undefined)).toEqual([]);
+  });
+});

--- a/src/app/_lib/normalize-errors.ts
+++ b/src/app/_lib/normalize-errors.ts
@@ -1,16 +1,48 @@
+type ApiErrorItem = {
+  code?: string;
+  field?: string;
+  message?: string;
+};
+
+function isApiErrorItem(value: unknown): value is ApiErrorItem {
+  return typeof value === "object" && value !== null && "message" in value;
+}
+
+function messagesFromApiErrorItems(items: ApiErrorItem[]): string[] {
+  return items
+    .map((item) => item.message)
+    .filter((message): message is string => typeof message === "string" && message.length > 0);
+}
+
 export function normalizeErrors(errors: unknown): string[] {
   if (errors == null) return [];
-
-  if (Array.isArray(errors)) {
-    return errors.flatMap(normalizeErrors);
-  }
 
   if (typeof errors === "string") {
     return errors.length > 0 ? [errors] : [];
   }
 
+  if (Array.isArray(errors)) {
+    if (errors.length === 0) return [];
+
+    if (errors.every((item) => typeof item === "string")) {
+      return errors.filter((item): item is string => item.length > 0);
+    }
+
+    if (errors.every(isApiErrorItem)) {
+      return messagesFromApiErrorItems(errors);
+    }
+
+    return errors.flatMap(normalizeErrors);
+  }
+
   if (typeof errors === "object") {
-    return Object.values(errors).flatMap(normalizeErrors);
+    const record = errors as Record<string, unknown>;
+
+    if (Array.isArray(record.errors)) {
+      return normalizeErrors(record.errors);
+    }
+
+    return Object.values(record).flatMap(normalizeErrors);
   }
 
   return [String(errors)];


### PR DESCRIPTION
## Summary
- Update `normalizeErrors` to read `message` from the API's structured `{ errors: [...] }` format (platform hardening / `ApiErrorRenderable`)
- Keep compatibility with legacy string arrays and Devise nested field errors (`auth.service`)
- Add unit tests for the new and legacy shapes

## Test plan
- [x] `npm test -- src/app/_lib/normalize-errors.test.ts`
- [ ] Submit an invalid beer form → UI shows only human messages (e.g. "Name não pode ficar em branco"), not `validation_error` / field names
- [ ] Sign-up / login validation still shows readable errors


Made with [Cursor](https://cursor.com)