### PR TITLE
feat(ci): eslint in GHA — plan 08 Phase 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           node-version: "20"
           cache: npm
       - run: npm ci
+      - run: npm run lint
       - run: npm run test:coverage
       - run: npm run build
         env:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,7 @@ const eslintConfig = defineConfig([
     ".next/**",
     "out/**",
     "build/**",
+    "coverage/**",
     "next-env.d.ts",
   ]),
 ]);

--- a/src/app/_components/AppearanceProvider.tsx
+++ b/src/app/_components/AppearanceProvider.tsx
@@ -1,12 +1,24 @@
 "use client";
 
-import {createContext, ReactNode, useContext, useEffect, useMemo, useState} from "react";
 import {
-  AppearanceMode,
-  applyAppearance,
-  readStoredAppearance,
-  storeAppearance,
-} from "@/app/_lib/appearance";
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useSyncExternalStore,
+} from "react";
+import {AppearanceMode, applyAppearance} from "@/app/_lib/appearance";
+import {
+  getAppearanceServerSnapshot,
+  getAppearanceSnapshot,
+  getSystemColorSchemeServerSnapshot,
+  getSystemColorSchemeSnapshot,
+  setAppearanceMode,
+  subscribeAppearance,
+  subscribeSystemColorScheme,
+} from "@/app/_lib/appearance-store";
 
 type AppearanceContextValue = {
   mode: AppearanceMode;
@@ -17,43 +29,27 @@ type AppearanceContextValue = {
 const AppearanceContext = createContext<AppearanceContextValue | null>(null);
 
 export function AppearanceProvider({children}: {children: ReactNode}) {
-  const [mode, setModeState] = useState<AppearanceMode>("system");
-  const [isDark, setIsDark] = useState(false);
-  const [ready, setReady] = useState(false);
+  const mode = useSyncExternalStore(
+    subscribeAppearance,
+    getAppearanceSnapshot,
+    getAppearanceServerSnapshot
+  );
+  const systemPrefersDark = useSyncExternalStore(
+    subscribeSystemColorScheme,
+    getSystemColorSchemeSnapshot,
+    getSystemColorSchemeServerSnapshot
+  );
+  const isDark = mode === "dark" || (mode === "system" && systemPrefersDark);
 
   useEffect(() => {
-    const stored = readStoredAppearance();
-    setModeState(stored);
-    applyAppearance(stored);
-    setIsDark(document.documentElement.classList.contains("dark"));
-    setReady(true);
+    applyAppearance(mode);
+  }, [mode, systemPrefersDark]);
+
+  const setMode = useCallback((next: AppearanceMode) => {
+    setAppearanceMode(next);
   }, []);
 
-  useEffect(() => {
-    if (!ready) return;
-
-    applyAppearance(mode);
-    setIsDark(document.documentElement.classList.contains("dark"));
-
-    if (mode !== "system") return;
-
-    const media = window.matchMedia("(prefers-color-scheme: dark)");
-    const syncSystem = () => {
-      applyAppearance("system");
-      setIsDark(document.documentElement.classList.contains("dark"));
-    };
-
-    media.addEventListener("change", syncSystem);
-    return () => media.removeEventListener("change", syncSystem);
-  }, [mode, ready]);
-
-  const setMode = (next: AppearanceMode) => {
-    setModeState(next);
-    storeAppearance(next);
-    setIsDark(document.documentElement.classList.contains("dark"));
-  };
-
-  const value = useMemo(() => ({mode, setMode, isDark}), [mode, isDark]);
+  const value = useMemo(() => ({mode, setMode, isDark}), [mode, setMode, isDark]);
 
   return <AppearanceContext.Provider value={value}>{children}</AppearanceContext.Provider>;
 }

--- a/src/app/_lib/appearance-store.ts
+++ b/src/app/_lib/appearance-store.ts
@@ -1,0 +1,40 @@
+import {
+  AppearanceMode,
+  readStoredAppearance,
+  storeAppearance,
+} from "@/app/_lib/appearance";
+
+const appearanceListeners = new Set<() => void>();
+
+export function subscribeAppearance(listener: () => void): () => void {
+  appearanceListeners.add(listener);
+  return () => appearanceListeners.delete(listener);
+}
+
+export function getAppearanceSnapshot(): AppearanceMode {
+  return readStoredAppearance();
+}
+
+export function getAppearanceServerSnapshot(): AppearanceMode {
+  return "system";
+}
+
+export function setAppearanceMode(mode: AppearanceMode): void {
+  storeAppearance(mode);
+  appearanceListeners.forEach((listener) => listener());
+}
+
+export function subscribeSystemColorScheme(listener: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  const media = window.matchMedia("(prefers-color-scheme: dark)");
+  media.addEventListener("change", listener);
+  return () => media.removeEventListener("change", listener);
+}
+
+export function getSystemColorSchemeSnapshot(): boolean {
+  return window.matchMedia("(prefers-color-scheme: dark)").matches;
+}
+
+export function getSystemColorSchemeServerSnapshot(): boolean {
+  return false;
+}

--- a/src/app/organizations/[id]/page.tsx
+++ b/src/app/organizations/[id]/page.tsx
@@ -20,26 +20,50 @@ function Page() {
   > | null>(null);
   const [loading, setLoading] = useState(true);
 
+  const isOwnOrgAdmin =
+    user != null &&
+    !Number.isNaN(id) &&
+    canManageOrganization(user) &&
+    user.organization?.id === id;
+
   useEffect(() => {
-    if (!user || Number.isNaN(id)) return;
+    if (!user || Number.isNaN(id) || isOwnOrgAdmin) return;
 
-    if (isSuperAdmin(user)) {
-      setLoading(true);
-      void platformOrganizationsService
-        .show(id)
-        .then(setOrganization)
-        .finally(() => setLoading(false));
+    if (!isSuperAdmin(user)) {
+      router.replace("/organizations");
       return;
     }
 
-    if (canManageOrganization(user) && user.organization?.id === id) {
-      setOrganization(user.organization);
-      setLoading(false);
-      return;
-    }
+    let cancelled = false;
+    void platformOrganizationsService
+      .show(id)
+      .then((org) => {
+        if (!cancelled) setOrganization(org);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
 
-    router.replace("/organizations");
-  }, [id, router, user]);
+    return () => {
+      cancelled = true;
+    };
+  }, [id, isOwnOrgAdmin, router, user]);
+
+  if (!user || Number.isNaN(id)) {
+    return <Loading/>;
+  }
+
+  if (isOwnOrgAdmin && user.organization) {
+    return (
+      <OrganizationProfilePage
+        organization={user.organization}
+        onOrganizationUpdated={setOrganization}
+        updateForm={platformOrganizationsService.updateForm}
+        updateOperational={platformOrganizationsService.update}
+        showRegionalSettings={!isSuperAdmin(user)}
+      />
+    );
+  }
 
   if (loading || !organization) {
     return <Loading/>;

--- a/src/app/organizations/components/OrganizationForm.tsx
+++ b/src/app/organizations/components/OrganizationForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import {FormEvent, useEffect, useState} from "react";
+import {FormEvent, useState} from "react";
 import {Buttons, Card, FormErrors, Input, Label} from "@/app/_components";
 import {Organization} from "@/app/_types";
 import {useTranslations} from "@/app/_hooks/useTranslations";
@@ -26,12 +26,6 @@ export function OrganizationForm({
   const [name, setName] = useState(defaultValues.name ?? "");
   const [phone, setPhone] = useState(defaultValues.phone ?? "");
   const [preview, setPreview] = useState<string | null>(defaultValues.logo_url ?? null);
-
-  useEffect(() => {
-    setName(defaultValues.name ?? "");
-    setPhone(defaultValues.phone ?? "");
-    setPreview(defaultValues.logo_url ?? null);
-  }, [defaultValues.id, defaultValues.name, defaultValues.phone, defaultValues.logo_url]);
 
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();

--- a/src/app/organizations/components/OrganizationProfilePage.tsx
+++ b/src/app/organizations/components/OrganizationProfilePage.tsx
@@ -84,6 +84,7 @@ export function OrganizationProfilePage({
       </div>
 
       <OrganizationForm
+        key={`${current.id}-${current.name}-${current.phone}-${current.logo_url ?? ""}`}
         defaultValues={current}
         errors={errors}
         loading={saving}

--- a/src/app/tables/components/TableRow.tsx
+++ b/src/app/tables/components/TableRow.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import {Table} from "@/app/_types";
-import {useEffect, useState} from "react";
+import {useState} from "react";
 import Link from "next/link";
 import {DestroyButton, EditButton, InlineInput} from "@/app/_components";
 import {useTranslations} from "@/app/_hooks/useTranslations";
@@ -19,10 +19,11 @@ export function TableRow({table, onUpdate, onDelete, readOnly = false}: Props) {
   const [name, setName] = useState(table.name)
   const [chairs, setChairs] = useState(String(table.chairs ?? 0))
 
-  useEffect(() => {
+  const beginEdit = () => {
     setName(table.name)
     setChairs(String(table.chairs ?? 0))
-  }, [table.name, table.chairs])
+    setIsEditing(true)
+  }
 
   const save = async () => {
     const trimmedName = name.trim()
@@ -117,7 +118,7 @@ export function TableRow({table, onUpdate, onDelete, readOnly = false}: Props) {
           </Link>
           {!readOnly && (
             <div className="flex gap-1 opacity-0 transition group-hover:opacity-100">
-              <EditButton onClick={() => setIsEditing(true)}/>
+              <EditButton onClick={beginEdit}/>
               <DestroyButton onClick={() => onDelete(Number(table.id))}/>
             </div>
           )}


### PR DESCRIPTION
## Summary
Completes **React Phase 3** of plan 08 (companion to API PR #45):
- `npm run lint` in GitHub Actions
- Fix 5 `react-hooks/set-state-in-effect` errors (appearance, org page, forms, tables)
- Ignore `coverage/` in eslint config

## Backend companion
- https://github.com/Sartori-RIA/ubuteco_api/pull/45

## Test plan
- [x] `npm run lint` — 0 errors
- [ ] GHA green


Made with [Cursor](https://cursor.com)