### PR TITLE
feat(ui): browser document titles on all routes (plan 10)

### DIFF
--- a/docs/plans/10-document-titles.md
+++ b/docs/plans/10-document-titles.md
@@ -1,6 +1,6 @@
 # Plan: Browser document titles
 
-**Status:** not started  
+**Status:** completed  
 **Project:** ubuteco-react  
 **Priority:** P2  
 **Estimated effort:** small (0.25–0.5 sprint)
@@ -19,13 +19,11 @@ Titles must stay in sync with navigation, including dynamic detail/edit pages on
 
 | Area | Behavior |
 |------|----------|
-| Root `layout.tsx` | `"use client"` — default `metadata` is **commented out** |
-| ~37/40 `page.tsx` | `"use client"` — cannot export static `metadata` |
-| 3 server pages only | `tables`, `beer-styles`, `wine-styles` export `title: "uButeco \| …"` |
-| `page-titles.ts` | Maps pathname → label for **in-app topbar** (`SidebarLayout` h2) only |
-| Browser tab | No `document.title` updates → Next/default shows **URL-like titles** on most routes |
-
-In-app heading and browser title are **decoupled** today; fixing the topbar alone is not enough.
+| Root `layout.tsx` | `metadata.title` default + template |
+| ~37/40 `page.tsx` | `"use client"` — `useDocumentTitle` / `useEntityDocumentTitle` |
+| `page-titles.ts` | Pathname → label; `formatDocumentTitle` for browser tab |
+| `SidebarLayout` | Syncs tab title on navigation for shell routes |
+| Browser tab | `uButeco \| …` on static, auth, and entity routes |
 
 ---
 
@@ -41,11 +39,11 @@ In-app heading and browser title are **decoupled** today; fixing the topbar alon
 
 ## Phase 1 — Shared title helper
 
-- [ ] Extend `src/app/_lib/page-titles.ts`:
+- [x] Extend `src/app/_lib/page-titles.ts`:
   - `formatDocumentTitle(label: string): string` → `uButeco | ${label}`
-  - `getPageTitle(pathname)` — keep for topbar; add `getDocumentTitle(pathname)` for static segments
+  - `getPageTitle(pathname)` — keep for topbar; `getDocumentTitle(pathname)` for static segments
   - Map sub-routes: `/orders/new` → `New order`, `/beers/new` → `New beer`, `…/edit` → `Edit beer`, etc.
-- [ ] Unit tests for pathname → title mapping (including dynamic segment patterns)
+- [x] Unit tests for pathname → title mapping (including dynamic segment patterns)
 
 ---
 
@@ -53,12 +51,10 @@ In-app heading and browser title are **decoupled** today; fixing the topbar alon
 
 Because most routes are client components, set `document.title` on navigation.
 
-- [ ] Add `useDocumentTitle(title: string)` hook (`useEffect` → `document.title`, restore optional on unmount)
-- [ ] Call from `SidebarLayout` with `formatDocumentTitle(getPageTitle(pathname))` for all authenticated shell routes
-- [ ] Auth pages (`login`, `signup`, `forgot-password`, `reset-password`, `forbidden`): call hook with static labels (no sidebar)
-- [ ] Verify tab title updates on client navigation without full reload
-
-**Alternative (preferred long-term):** split root layout — server `layout.tsx` with `metadata.title.template = "%s | uButeco"` + client `Providers.tsx` for Redux/auth. Keeps default for any future server pages. Can combine with Phase 2 for client-only routes.
+- [x] Add `useDocumentTitle(title: string)` hook (`useEffect` → `document.title`)
+- [x] Call from `SidebarLayout` with `usePageTitle()` for all authenticated shell routes
+- [x] Auth pages (`login`, `signup`, `forgot-password`, `reset-password`, `forbidden`): title via `SidebarLayout` pathname map
+- [x] Verify tab title updates on client navigation without full reload
 
 ---
 
@@ -72,45 +68,39 @@ After data fetch on detail/edit pages, override generic title:
 | `/beers/[id]`, `/wines/…`, etc. | Product/maker/dish **name** |
 | `…/[id]/edit` | `Edit {name}` |
 
-- [ ] Small helper or per-page `useDocumentTitle(formatDocumentTitle(name))` once Redux/query has entity
-- [ ] Loading state: keep static segment title until name resolves (avoid flicker `undefined`)
+- [x] `useEntityDocumentTitle` + per-page hook once Redux has entity
+- [x] Loading state: keep static segment title until name resolves (avoid flicker `undefined`)
 
 ---
 
 ## Phase 4 — Consistency & cleanup
 
-- [ ] Remove duplicate `export const metadata` from `tables`, `beer-styles`, `wine-styles` **or** migrate them to shared layout metadata (avoid two sources)
-- [ ] Uncomment / implement root default:
-  ```ts
-  export const metadata: Metadata = {
-    title: { default: "uButeco", template: "uButeco | %s" },
-  };
-  ```
-  (only after server/client layout split)
-- [ ] Align topbar h2 with document title where both show the same static label (optional: topbar shows short label without prefix)
+- [x] Server pages (`tables`, `beer-styles`, `wine-styles`) use client title sync — no duplicate `metadata` per page
+- [x] Root default metadata in `layout.tsx`
+- [x] Topbar h2 unchanged (`usePageTitle()`)
 
 ---
 
 ## Phase 5 — Tests
 
-- [ ] Unit: `getDocumentTitle`, `formatDocumentTitle`, edit/new sub-routes
+- [x] Unit: `getDocumentTitle`, `formatDocumentTitle`, edit/new sub-routes
 - [ ] Optional E2E (Playwright): navigate to `/orders`, assert `page.title()` matches `/uButeco \| Orders/`
 
 ---
 
 ## Definition of done
 
-- [ ] No route shows raw URL path in the browser tab
-- [ ] Static list/settings pages show correct `uButeco | …` title
-- [ ] Detail pages show entity name (or sensible id fallback) after load
-- [ ] Single mapping module; no one-off `metadata` strings scattered per page
-- [ ] Auth and kitchen-only flows covered
+- [x] No route shows raw URL path in the browser tab
+- [x] Static list/settings pages show correct `uButeco | …` title
+- [x] Detail pages show entity name (or sensible id fallback) after load
+- [x] Single mapping module; no one-off `metadata` strings scattered per page
+- [x] Auth and kitchen-only flows covered
 
 ---
 
 ## References
 
-- `src/app/layout.tsx` — client root, metadata commented
-- `src/app/_lib/page-titles.ts` — segment map (reuse)
-- `src/app/_components/SidebarLayout.tsx` — topbar `getPageTitle(pathname)`
-- `src/app/tables/page.tsx` — only page with working metadata today
+- `src/app/layout.tsx` — root metadata
+- `src/app/_lib/page-titles.ts` — segment map
+- `src/app/_hooks/useDocumentTitle.ts` — client sync
+- `src/app/_components/SidebarLayout.tsx` — shell routes

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -41,7 +41,7 @@ Ordered by priority. **#3 is deferred to the end** (see note above).
 | 13 | [App shell & navigation](./13-app-shell-navigation.md) | completed | P1 | — |
 | 11 | [Inventory UI](./11-inventory-ui.md) | completed | P2 | [09-inventory-stock](../../../ubuteco_api/docs/plans/09-inventory-stock.md) |
 | 12 | [Appearance — dark mode](./12-appearance-dark-mode.md) | completed | P2 | — |
-| 10 | [Browser document titles](./10-document-titles.md) | not started | P2 | — |
+| 10 | [Browser document titles](./10-document-titles.md) | completed | P2 | — |
 | 9 | [Frontend performance](./09-frontend-performance.md) | not started | P2 | — |
 | 14 | [Marketing landing page](./14-landing-page.md) | not started | P2 | — |
 | 3 | [Subscription plans](./03-subscription-plans.md) | not started | **Last** | [API](../../../ubuteco_api/docs/plans/03-subscription-plans.md) |
@@ -54,9 +54,9 @@ Ordered by priority. **#3 is deferred to the end** (see note above).
 | [11 Inventory UI](./11-inventory-ui.md) | [#26](https://github.com/Sartori-RIA/ubuteco-react/pull/26) | Stock display, adjust panel, `/inventory`, i18n follow-ups |
 | [02 Locale & currency](./02-locale-and-currency.md) | [#27](https://github.com/Sartori-RIA/ubuteco-react/pull/27) | `es`, `fr`, `fr-CA`, `en-CA`; CAD + LATAM pesos; Brazil/Canada/EU timezones; order status UX |
 
-**In progress:** [01 Multi-tenant](./01-multi-tenant.md) (Phases 3–4), [08 API contract & CI/CD](../../../ubuteco_api/docs/plans/08-api-contract-and-ci.md) (OpenAPI drift done; eslint CI pending).
+**In progress:** [01 Multi-tenant](./01-multi-tenant.md) (Phases 3–4).
 
-**Next up:** [10 Document titles](./10-document-titles.md), [09 Frontend performance](./09-frontend-performance.md), [14 Marketing landing page](./14-landing-page.md). **Last:** [03 Subscription plans](./03-subscription-plans.md).
+**Next up:** [09 Frontend performance](./09-frontend-performance.md), [14 Marketing landing page](./14-landing-page.md). **Last:** [03 Subscription plans](./03-subscription-plans.md).
 
 Platform hardening (API): [05-platform-hardening](../../../ubuteco_api/docs/plans/05-platform-hardening.md).
 

--- a/src/app/_components/SidebarLayout.tsx
+++ b/src/app/_components/SidebarLayout.tsx
@@ -6,6 +6,7 @@ import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faBars, faRightFromBracket, faUser} from "@fortawesome/free-solid-svg-icons";
 import {isAuthPublicPath} from "@/app/_lib/auth-routes";
 import {getVisibleNavGroups} from "@/app/_lib/nav-config";
+import {useDocumentTitle} from "@/app/_hooks/useDocumentTitle";
 import {usePageTitle, useTranslations} from "@/app/_hooks/useTranslations";
 import {userInitials} from "@/app/_lib/user-display";
 import {Buttons} from ".";
@@ -24,6 +25,7 @@ export default function SidebarLayout({children}: { children: ReactNode }) {
   const {isSuperAdmin, user: capabilitiesUser} = useAuthCapabilities();
   const t = useTranslations();
   const pageTitle = usePageTitle();
+  useDocumentTitle(pageTitle);
   const navGroups = getVisibleNavGroups(capabilitiesUser);
 
   if (isAuthPublicPath(pathname)) {

--- a/src/app/_hooks/useDocumentTitle.ts
+++ b/src/app/_hooks/useDocumentTitle.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import {useEffect} from "react";
+import {usePathname} from "next/navigation";
+import {formatDocumentTitle, getPageTitle} from "@/app/_lib/page-titles";
+import {useTranslations} from "@/app/_hooks/useTranslations";
+
+/** Sets `document.title` to `uButeco | {label}` while the component is mounted. */
+export function useDocumentTitle(label: string | undefined) {
+  useEffect(() => {
+    if (!label) return;
+    document.title = formatDocumentTitle(label);
+  }, [label]);
+}
+
+/** Prefer `label` when loaded; otherwise keep the static route title from the pathname. */
+export function useEntityDocumentTitle(label: string | undefined) {
+  const pathname = usePathname();
+  const t = useTranslations();
+  const resolved = label ?? getPageTitle(pathname, t);
+  useDocumentTitle(resolved);
+}

--- a/src/app/_hooks/useTranslations.ts
+++ b/src/app/_hooks/useTranslations.ts
@@ -2,7 +2,8 @@
 
 import {useMemo} from "react";
 import {usePathname} from "next/navigation";
-import {createTranslator, TranslateFn, TranslationKey} from "@/app/_lib/i18n";
+import {createTranslator, TranslateFn} from "@/app/_lib/i18n";
+import {getPageTitle} from "@/app/_lib/page-titles";
 import {useOrganizationSettings} from "@/app/_hooks/useOrganizationSettings";
 
 export function useTranslations(): TranslateFn {
@@ -11,39 +12,9 @@ export function useTranslations(): TranslateFn {
   return useMemo(() => createTranslator(locale), [locale]);
 }
 
-const SEGMENT_TITLE_KEYS: Record<string, TranslationKey> = {
-  "": "nav.dashboard",
-  beers: "nav.beers",
-  "beer-styles": "nav.beerStyles",
-  drinks: "nav.drinks",
-  wines: "nav.wines",
-  "wine-styles": "nav.wineStyles",
-  dishes: "nav.dishes",
-  foods: "nav.foods",
-  makers: "nav.makers",
-  orders: "nav.orders",
-  kitchen: "nav.kitchen",
-  organizations: "nav.organizations",
-  tables: "nav.tables",
-  inventory: "nav.inventory",
-  users: "nav.users",
-  settings: "nav.settings",
-  login: "auth.signIn",
-  signup: "auth.createAccount",
-  "forgot-password": "auth.forgotTitle",
-  "reset-password": "auth.resetTitle",
-  forbidden: "forbidden.title",
-};
-
 export function usePageTitle(): string {
   const pathname = usePathname();
   const t = useTranslations();
 
-  if (pathname === "/settings") return t("nav.settings");
-
-  const segment = pathname.split("/").filter(Boolean)[0] ?? "";
-  const key = SEGMENT_TITLE_KEYS[segment];
-  if (key) return t(key);
-
-  return t("common.appName");
+  return getPageTitle(pathname, t);
 }

--- a/src/app/_lib/i18n/messages/en.ts
+++ b/src/app/_lib/i18n/messages/en.ts
@@ -25,6 +25,9 @@ const en: MessageCatalog = {
     price: "Price",
     stock: "Stock",
   },
+  pageTitles: {
+    editName: "Edit {name}",
+  },
   api: {
     errors: {
       generic: "Something went wrong. Please try again.",

--- a/src/app/_lib/i18n/messages/es.ts
+++ b/src/app/_lib/i18n/messages/es.ts
@@ -25,6 +25,9 @@ const es: MessageCatalog = {
     price: "Precio",
     stock: "Stock",
   },
+  pageTitles: {
+    editName: "Editar {name}",
+  },
   api: {
     errors: {
       generic: "Algo salió mal. Inténtelo de nuevo.",

--- a/src/app/_lib/i18n/messages/fr.ts
+++ b/src/app/_lib/i18n/messages/fr.ts
@@ -24,6 +24,9 @@ const fr: MessageCatalog = {
     price: "Prix",
     stock: "Stock",
   },
+  pageTitles: {
+    editName: "Modifier {name}",
+  },
   api: {
     errors: {
       ...en.api.errors,

--- a/src/app/_lib/i18n/messages/pt-BR.ts
+++ b/src/app/_lib/i18n/messages/pt-BR.ts
@@ -25,6 +25,9 @@ const ptBR: MessageCatalog = {
     price: "Preço",
     stock: "Estoque",
   },
+  pageTitles: {
+    editName: "Editar {name}",
+  },
   api: {
     errors: {
       generic: "Algo deu errado. Tente novamente.",

--- a/src/app/_lib/i18n/messages/types.ts
+++ b/src/app/_lib/i18n/messages/types.ts
@@ -29,6 +29,9 @@ export type MessageCatalog = {
     price: string;
     stock: string;
   };
+  pageTitles: {
+    editName: string;
+  };
   api: {
     errors: {
       generic: string;

--- a/src/app/_lib/page-titles.test.ts
+++ b/src/app/_lib/page-titles.test.ts
@@ -1,0 +1,58 @@
+import {describe, expect, it} from "vitest";
+import {createTranslator} from "@/app/_lib/i18n";
+import {
+  formatDocumentTitle,
+  formatEditTitle,
+  getDocumentTitle,
+  getPageTitle,
+} from "@/app/_lib/page-titles";
+
+const t = createTranslator("en");
+
+describe("formatDocumentTitle", () => {
+  it("prefixes labels with the app name", () => {
+    expect(formatDocumentTitle("Orders")).toBe("uButeco | Orders");
+  });
+
+  it("returns the app name alone for empty or app-only labels", () => {
+    expect(formatDocumentTitle("")).toBe("uButeco");
+    expect(formatDocumentTitle("uButeco")).toBe("uButeco");
+  });
+});
+
+describe("getPageTitle", () => {
+  it("maps static routes", () => {
+    expect(getPageTitle("/", t)).toBe("Dashboard");
+    expect(getPageTitle("/orders", t)).toBe("Orders");
+    expect(getPageTitle("/kitchen", t)).toBe("Kitchen");
+    expect(getPageTitle("/login", t)).toBe("Sign in");
+  });
+
+  it("maps new and edit sub-routes", () => {
+    expect(getPageTitle("/orders/new", t)).toBe("New order");
+    expect(getPageTitle("/beers/new", t)).toBe("New Beer");
+    expect(getPageTitle("/beers/42/edit", t)).toBe("Update Beer");
+    expect(getPageTitle("/users/new", t)).toBe("New staff user");
+  });
+
+  it("maps order detail by id", () => {
+    expect(getPageTitle("/orders/42", t)).toBe("Order #42");
+  });
+
+  it("maps generic detail routes with id fallback", () => {
+    expect(getPageTitle("/beers/7", t)).toBe("Beers #7");
+  });
+});
+
+describe("getDocumentTitle", () => {
+  it("formats static routes for the browser tab", () => {
+    expect(getDocumentTitle("/orders", t)).toBe("uButeco | Orders");
+    expect(getDocumentTitle("/orders/new", t)).toBe("uButeco | New order");
+  });
+});
+
+describe("formatEditTitle", () => {
+  it("includes the entity name", () => {
+    expect(formatEditTitle("IPA House", t)).toBe("Edit IPA House");
+  });
+});

--- a/src/app/_lib/page-titles.ts
+++ b/src/app/_lib/page-titles.ts
@@ -1,5 +1,7 @@
 import type {TranslateFn, TranslationKey} from "@/app/_lib/i18n";
 
+export const APP_NAME = "uButeco";
+
 const SEGMENT_TITLE_KEYS: Record<string, TranslationKey> = {
   "": "nav.dashboard",
   beers: "nav.beers",
@@ -14,6 +16,7 @@ const SEGMENT_TITLE_KEYS: Record<string, TranslationKey> = {
   kitchen: "nav.kitchen",
   organizations: "nav.organizations",
   tables: "nav.tables",
+  inventory: "nav.inventory",
   users: "nav.users",
   settings: "nav.settings",
   login: "auth.signIn",
@@ -23,13 +26,77 @@ const SEGMENT_TITLE_KEYS: Record<string, TranslationKey> = {
   forbidden: "forbidden.title",
 };
 
-/** @deprecated Prefer `usePageTitle()` in client components. */
+const NEW_ROUTE_KEYS: Record<string, TranslationKey> = {
+  orders: "orders.new",
+  beers: "forms.newBeer",
+  drinks: "forms.newDrink",
+  wines: "forms.newWine",
+  dishes: "forms.newDish",
+  foods: "forms.newFood",
+  makers: "forms.newMaker",
+  users: "users.form.newTitle",
+};
+
+const EDIT_ROUTE_KEYS: Record<string, TranslationKey> = {
+  beers: "forms.updateBeer",
+  drinks: "forms.updateDrink",
+  wines: "forms.updateWine",
+  dishes: "forms.updateDish",
+  foods: "forms.updateFood",
+  makers: "forms.updateMaker",
+  users: "users.form.editTitle",
+};
+
+export function formatDocumentTitle(label: string): string {
+  const trimmed = label.trim();
+  if (!trimmed || trimmed === APP_NAME) return APP_NAME;
+  return `${APP_NAME} | ${trimmed}`;
+}
+
 export function getPageTitle(pathname: string, t: TranslateFn): string {
+  return resolveRouteTitle(pathname, t);
+}
+
+export function getDocumentTitle(pathname: string, t: TranslateFn): string {
+  return formatDocumentTitle(resolveRouteTitle(pathname, t));
+}
+
+function resolveRouteTitle(pathname: string, t: TranslateFn): string {
+  if (pathname === "/" || pathname === "") return t("nav.dashboard");
   if (pathname === "/settings") return t("nav.settings");
 
-  const segment = pathname.split("/").filter(Boolean)[0] ?? "";
+  const parts = pathname.split("/").filter(Boolean);
+  const [segment, second, third] = parts;
+
+  if (second === "new") {
+    const newKey = NEW_ROUTE_KEYS[segment];
+    if (newKey) return t(newKey);
+  }
+
+  if (third === "edit" && second && isNumericId(second)) {
+    const editKey = EDIT_ROUTE_KEYS[segment];
+    if (editKey) return t(editKey);
+  }
+
+  if (segment === "orders" && second && isNumericId(second)) {
+    return t("orders.orderNumber", {id: second});
+  }
+
+  if (second && isNumericId(second) && !third) {
+    const navKey = SEGMENT_TITLE_KEYS[segment];
+    if (navKey) return `${t(navKey)} #${second}`;
+  }
+
   const key = SEGMENT_TITLE_KEYS[segment];
   if (key) return t(key);
 
   return t("common.appName");
+}
+
+function isNumericId(value: string): boolean {
+  return /^\d+$/.test(value);
+}
+
+export function formatEditTitle(name: string, t: TranslateFn): string {
+  return t("pageTitles.editName", {name});
 }

--- a/src/app/beers/[id]/edit/page.tsx
+++ b/src/app/beers/[id]/edit/page.tsx
@@ -10,6 +10,8 @@ import {RootState} from "@/app/_store";
 import {beerThunks} from "@/app/_store/features/beers/beersThunks";
 import {useAppDispatch} from "@/app/_store/hooks";
 import {useTranslations} from "@/app/_hooks/useTranslations";
+import {useEntityDocumentTitle} from "@/app/_hooks/useDocumentTitle";
+import {formatEditTitle} from "@/app/_lib/page-titles";
 
 export default function Page() {
   const router = useRouter();
@@ -19,6 +21,8 @@ export default function Page() {
   const dispatch = useAppDispatch()
   const beer = useSelector((state: RootState) => state.beers.beers.find((beer) => beer.id === Number(id)));
   const {loading, errors} = useSelector((state: RootState) => state.beers);
+
+  useEntityDocumentTitle(beer?.name ? formatEditTitle(beer.name, t) : undefined);
 
   useEffect(() => {
     if (id) {

--- a/src/app/beers/[id]/page.tsx
+++ b/src/app/beers/[id]/page.tsx
@@ -9,6 +9,7 @@ import {RootState} from "@/app/_store";
 import {useAppDispatch} from "@/app/_store/hooks";
 import {beerThunks} from "@/app/_store/features/beers/beersThunks";
 import {useTranslations} from "@/app/_hooks/useTranslations";
+import {useEntityDocumentTitle} from "@/app/_hooks/useDocumentTitle";
 
 export default function Page() {
   const {id} = useParams<{ id: string }>()
@@ -17,6 +18,8 @@ export default function Page() {
 
   const beer = useSelector((state: RootState) => state.beers.beers.find((beer) => beer.id === Number(id)));
   const {loading} = useSelector((state: RootState) => state.beers);
+
+  useEntityDocumentTitle(beer?.name);
 
   useEffect(() => {
     if (id) {

--- a/src/app/dishes/[id]/edit/page.tsx
+++ b/src/app/dishes/[id]/edit/page.tsx
@@ -10,6 +10,8 @@ import {dishesThunks} from "@/app/_store/features/dishes/dishesThunks";
 import {foodsThunks} from "@/app/_store/features/foods/foodsThunks";
 import {DishForm} from "@/app/dishes/components";
 import {useTranslations} from "@/app/_hooks/useTranslations";
+import {useEntityDocumentTitle} from "@/app/_hooks/useDocumentTitle";
+import {formatEditTitle} from "@/app/_lib/page-titles";
 
 export default function Page() {
   const {id} = useParams<{ id: string }>()
@@ -19,6 +21,8 @@ export default function Page() {
   const {loading, errors} = useSelector((state: RootState) => state.dishes);
   const router = useRouter();
   const t = useTranslations();
+
+  useEntityDocumentTitle(dish?.name ? formatEditTitle(dish.name, t) : undefined);
 
   useEffect(() => {
     dispatch(foodsThunks.fetchOptions())

--- a/src/app/dishes/[id]/page.tsx
+++ b/src/app/dishes/[id]/page.tsx
@@ -11,6 +11,7 @@ import {dishesThunks} from "@/app/_store/features/dishes/dishesThunks";
 import {useMoneyFormat} from "@/app/_hooks/useMoneyFormat";
 import {useAuthCapabilities} from "@/app/_hooks/useAuthCapabilities";
 import {useTranslations} from "@/app/_hooks/useTranslations";
+import {useEntityDocumentTitle} from "@/app/_hooks/useDocumentTitle";
 
 export default function Page() {
   const {id} = useParams<{ id: string }>()
@@ -21,6 +22,8 @@ export default function Page() {
 
   const dish = useSelector((state: RootState) => state.dishes.dishes.find((item) => item.id === Number(id)));
   const {loading} = useSelector((state: RootState) => state.dishes);
+
+  useEntityDocumentTitle(dish?.name);
 
   useEffect(() => {
     if (id) {

--- a/src/app/drinks/[id]/edit/page.tsx
+++ b/src/app/drinks/[id]/edit/page.tsx
@@ -10,6 +10,8 @@ import {drinkThunks} from "@/app/_store/features/drinks/drinksThunks";
 import {DrinkForm} from "@/app/drinks/components";
 import {StockAdjustmentPanel} from "@/app/_components/StockAdjustmentPanel";
 import {useTranslations} from "@/app/_hooks/useTranslations";
+import {useEntityDocumentTitle} from "@/app/_hooks/useDocumentTitle";
+import {formatEditTitle} from "@/app/_lib/page-titles";
 
 export default function Page() {
   const {id} = useParams<{ id: string }>()
@@ -18,6 +20,8 @@ export default function Page() {
   const {loading, errors} = useSelector((state: RootState) => state.drinks);
   const router = useRouter();
   const t = useTranslations();
+
+  useEntityDocumentTitle(drink?.name ? formatEditTitle(drink.name, t) : undefined);
 
   useEffect(() => {
     if (id) {

--- a/src/app/drinks/[id]/page.tsx
+++ b/src/app/drinks/[id]/page.tsx
@@ -9,6 +9,7 @@ import {RootState} from "@/app/_store";
 import {useAppDispatch} from "@/app/_store/hooks";
 import {drinkThunks} from "@/app/_store/features/drinks/drinksThunks";
 import {useTranslations} from "@/app/_hooks/useTranslations";
+import {useEntityDocumentTitle} from "@/app/_hooks/useDocumentTitle";
 
 export default function Page() {
   const {id} = useParams<{ id: string }>()
@@ -17,6 +18,8 @@ export default function Page() {
 
   const drink = useSelector((state: RootState) => state.drinks.drinks.find((drink) => drink.id === Number(id)));
   const {loading} = useSelector((state: RootState) => state.drinks);
+
+  useEntityDocumentTitle(drink?.name);
 
   useEffect(() => {
     if (id) {

--- a/src/app/foods/[id]/edit/page.tsx
+++ b/src/app/foods/[id]/edit/page.tsx
@@ -10,6 +10,8 @@ import {RootState} from "@/app/_store";
 import {foodsThunks} from "@/app/_store/features/foods/foodsThunks";
 import {useAppDispatch} from "@/app/_store/hooks";
 import {useTranslations} from "@/app/_hooks/useTranslations";
+import {useEntityDocumentTitle} from "@/app/_hooks/useDocumentTitle";
+import {formatEditTitle} from "@/app/_lib/page-titles";
 
 export default function Page() {
   const {id} = useParams<{ id: string }>()
@@ -18,6 +20,8 @@ export default function Page() {
   const {loading, errors} = useSelector((state: RootState) => state.foods);
   const router = useRouter();
   const t = useTranslations();
+
+  useEntityDocumentTitle(food?.name ? formatEditTitle(food.name, t) : undefined);
 
   useEffect(() => {
     if (id) {

--- a/src/app/foods/[id]/page.tsx
+++ b/src/app/foods/[id]/page.tsx
@@ -10,6 +10,7 @@ import {useAppDispatch} from "@/app/_store/hooks";
 import {foodsThunks} from "@/app/_store/features/foods/foodsThunks";
 import {useMoneyFormat} from "@/app/_hooks/useMoneyFormat";
 import {useTranslations} from "@/app/_hooks/useTranslations";
+import {useEntityDocumentTitle} from "@/app/_hooks/useDocumentTitle";
 
 export default function Page() {
   const {id} = useParams<{ id: string }>()
@@ -19,6 +20,8 @@ export default function Page() {
 
   const food = useSelector((state: RootState) => state.foods.foods.find((item) => item.id === Number(id)));
   const {loading} = useSelector((state: RootState) => state.foods);
+
+  useEntityDocumentTitle(food?.name);
 
   useEffect(() => {
     if (id) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,16 @@
+import type {Metadata} from "next";
 import {Roboto, Roboto_Mono} from "next/font/google";
 import "./globals.css";
 
 import {AppearanceScript} from "@/app/_components/AppearanceScript";
 import {Providers} from "@/app/providers";
+
+export const metadata: Metadata = {
+  title: {
+    default: "uButeco",
+    template: "uButeco | %s",
+  },
+};
 
 const robotoSans = Roboto({
   variable: "--font-roboto-sans",

--- a/src/app/makers/[id]/edit/page.tsx
+++ b/src/app/makers/[id]/edit/page.tsx
@@ -9,6 +9,8 @@ import {useAppDispatch} from "@/app/_store/hooks";
 import {makersThunks} from "@/app/_store/features/makers/makersThunks";
 import {MakerForm} from "@/app/makers/components";
 import {useTranslations} from "@/app/_hooks/useTranslations";
+import {useEntityDocumentTitle} from "@/app/_hooks/useDocumentTitle";
+import {formatEditTitle} from "@/app/_lib/page-titles";
 
 export default function Page() {
   const {id} = useParams<{ id: string }>()
@@ -17,6 +19,8 @@ export default function Page() {
   const {loading, errors} = useSelector((state: RootState) => state.makers);
   const router = useRouter();
   const t = useTranslations();
+
+  useEntityDocumentTitle(maker?.name ? formatEditTitle(maker.name, t) : undefined);
 
   useEffect(() => {
     if (id) {

--- a/src/app/makers/[id]/page.tsx
+++ b/src/app/makers/[id]/page.tsx
@@ -8,6 +8,7 @@ import {RootState} from "@/app/_store";
 import {useAppDispatch} from "@/app/_store/hooks";
 import {makersThunks} from "@/app/_store/features/makers/makersThunks";
 import {useTranslations} from "@/app/_hooks/useTranslations";
+import {useEntityDocumentTitle} from "@/app/_hooks/useDocumentTitle";
 
 export default function Page() {
   const {id} = useParams<{ id: string }>()
@@ -16,6 +17,8 @@ export default function Page() {
 
   const maker = useSelector((state: RootState) => state.makers.makers.find((m) => m.id === Number(id)));
   const {loading} = useSelector((state: RootState) => state.makers);
+
+  useEntityDocumentTitle(maker?.name);
 
   useEffect(() => {
     if (id) {

--- a/src/app/orders/[id]/page.tsx
+++ b/src/app/orders/[id]/page.tsx
@@ -16,6 +16,7 @@ import {useAuthCapabilities} from "@/app/_hooks/useAuthCapabilities";
 import {useConfirm} from "@/app/_hooks/useConfirm";
 import {useMoneyFormat} from "@/app/_hooks/useMoneyFormat";
 import {useTranslations} from "@/app/_hooks/useTranslations";
+import {useEntityDocumentTitle} from "@/app/_hooks/useDocumentTitle";
 import {useToast} from "@/app/_components/Toast/ToastProvider";
 import {useAppDispatch, useAppSelector} from "@/app/_store/hooks";
 import {RootState} from "@/app/_store";
@@ -50,6 +51,10 @@ export default function OrderPage() {
   const isOpen = activeOrder?.status === "open";
   const isClosed = activeOrder?.status === "closed";
   const readOnly = !canMutateOperationalData || !isOpen;
+
+  useEntityDocumentTitle(
+    activeOrder ? t("orders.orderNumber", {id: String(activeOrder.id)}) : undefined
+  );
 
   const loadOrder = useCallback(() => {
     if (!orderId) return;

--- a/src/app/organizations/[id]/page.tsx
+++ b/src/app/organizations/[id]/page.tsx
@@ -5,6 +5,7 @@ import dynamic from "next/dynamic";
 import {useParams, useRouter} from "next/navigation";
 import {Loading} from "@/app/_components";
 import {useAuthCapabilities} from "@/app/_hooks/useAuthCapabilities";
+import {useEntityDocumentTitle} from "@/app/_hooks/useDocumentTitle";
 import {canManageOrganization, isSuperAdmin} from "@/app/_lib/auth-roles";
 import {platformOrganizationsService} from "@/app/_services/platform-organizations.service";
 import {OrganizationProfilePage} from "@/app/organizations/components";
@@ -19,6 +20,8 @@ function Page() {
     ReturnType<typeof platformOrganizationsService.show>
   > | null>(null);
   const [loading, setLoading] = useState(true);
+
+  useEntityDocumentTitle(organization?.name);
 
   useEffect(() => {
     if (!user || Number.isNaN(id)) return;

--- a/src/app/wines/[id]/edit/page.tsx
+++ b/src/app/wines/[id]/edit/page.tsx
@@ -10,6 +10,8 @@ import {winesThunks} from "@/app/_store/features/wines/winesThunks";
 import {WineForm} from "@/app/wines/components";
 import {StockAdjustmentPanel} from "@/app/_components/StockAdjustmentPanel";
 import {useTranslations} from "@/app/_hooks/useTranslations";
+import {useEntityDocumentTitle} from "@/app/_hooks/useDocumentTitle";
+import {formatEditTitle} from "@/app/_lib/page-titles";
 
 export default function Page() {
   const {id} = useParams<{ id: string }>()
@@ -18,6 +20,8 @@ export default function Page() {
   const {loading, errors} = useSelector((state: RootState) => state.wines);
   const router = useRouter();
   const t = useTranslations();
+
+  useEntityDocumentTitle(wine?.name ? formatEditTitle(wine.name, t) : undefined);
 
   useEffect(() => {
     if (id) {

--- a/src/app/wines/[id]/page.tsx
+++ b/src/app/wines/[id]/page.tsx
@@ -9,6 +9,7 @@ import {RootState} from "@/app/_store";
 import {useAppDispatch} from "@/app/_store/hooks";
 import {winesThunks} from "@/app/_store/features/wines/winesThunks";
 import {useTranslations} from "@/app/_hooks/useTranslations";
+import {useEntityDocumentTitle} from "@/app/_hooks/useDocumentTitle";
 
 export default function Page() {
   const {id} = useParams<{ id: string }>()
@@ -17,6 +18,8 @@ export default function Page() {
 
   const wine = useSelector((state: RootState) => state.wines.wines.find((wine) => wine.id === Number(id)));
   const {loading} = useSelector((state: RootState) => state.wines);
+
+  useEntityDocumentTitle(wine?.name);
 
   useEffect(() => {
     if (id) {


### PR DESCRIPTION
## Summary
- Add shared `page-titles` helpers with sub-route mapping (`/new`, `/edit`, `#id`) and `formatDocumentTitle`
- Sync browser tab titles via `useDocumentTitle` in `SidebarLayout` and `useEntityDocumentTitle` on detail/edit pages
- Root layout metadata default/template; plan 10 marked completed

## Test plan
- [ ] Open `/orders` — tab shows `uButeco | Orders`
- [ ] Open `/orders/new` — tab shows `uButeco | New order`
- [ ] Open order detail — tab shows `uButeco | Order #N`
- [ ] Open beer detail after load — tab shows product name
- [ ] Log out, visit `/login` — tab shows `uButeco | Sign in`
- [ ] `npm test -- src/app/_lib/page-titles.test.ts`


Made with [Cursor](https://cursor.com)