### PR TITLE
feat(marketing): public landing page, legal pages (plan 14)

### DIFF
--- a/docs/plans/14-landing-page.md
+++ b/docs/plans/14-landing-page.md
@@ -1,6 +1,6 @@
 # Plan: Marketing landing page (frontend)
 
-**Status:** not started  
+**Status:** in progress  
 **Project:** ubuteco-react  
 **Backend:** — (optional: public stats or lead capture API later)  
 **Branch:** `feature/landing-page`  
@@ -14,90 +14,67 @@ Public marketing site that explains uButeco to bar and restaurant owners, drives
 
 ---
 
-## Current state
-
-- Root `/` is the authenticated dashboard inside `SidebarLayout`.
-- Public routes today: `/login`, `/signup`, `/forgot-password`, `/reset-password` only (`auth-routes.ts`).
-- No public homepage, pricing page, or product narrative.
-- Sign-up flow already creates org + user — landing CTA can point to `/signup`.
-
----
-
 ## Phase 1 — Routing & shell split
 
-- [ ] Add public route group (e.g. `(marketing)/`) with its own layout — **no** sidebar, no auth guard chrome.
-- [ ] Decide entry URLs (recommendation):
-  - `/` → landing (logged-out) or redirect to dashboard (logged-in)
-  - `/app` or keep dashboard at `/` for authed users via redirect in `page.tsx`
-- [ ] Extend `isAuthPublicPath` / `AuthGuard` so marketing pages are public.
-- [ ] Header: logo, “Sign in”, primary CTA “Start free” → `/signup`.
+- [x] Public landing at `/` when logged out — no sidebar (`isMarketingShellPath`)
+- [x] Authenticated `/` → dashboard (existing behavior)
+- [x] `AuthGuard` + `SidebarLayout` skip app shell for marketing/auth paths
+- [x] Header: logo, “Sign in”, primary CTA “Start free” → `/signup`
 
-**Files:** `src/app/(marketing)/layout.tsx`, `src/app/page.tsx` (or split), `auth-routes.ts`, `AuthGuard.tsx`
+**Files:** `src/app/_components/marketing/*`, `auth-routes.ts`, `AuthGuard.tsx`, `SidebarLayout.tsx`, `page.tsx`
 
 ---
 
 ## Phase 2 — Page content (MVP)
 
-Single long-scroll landing or few sections on one page:
+- [x] **Hero** — headline, subhead, CTA, kitchen queue mock
+- [x] **Problem / solution** — orders, kitchen queue, catalog, multi-tenant org
+- [x] **Feature blocks** (4) — Operations, Menu & catalog, Kitchen, Settings/regional
+- [x] **Social proof placeholder** — “built for bars & restaurants”
+- [x] **Footer** — Sign in, Sign up, contact placeholder
 
-- [ ] **Hero** — headline, subhead, CTA, optional product screenshot/mock.
-- [ ] **Problem / solution** — orders, kitchen queue, catalog, multi-tenant org.
-- [ ] **Feature blocks** (3–4) — Operations, Menu & catalog, Kitchen, Settings/regional.
-- [ ] **Social proof placeholder** — testimonials or “built for bars & restaurants” (copy only until real quotes).
-- [ ] **Footer** — links Sign in, Sign up, contact placeholder.
-
-Copy in **pt-BR** first (primary market); **en** optional in same phase or Phase 4.
+Copy in **pt-BR** (+ en, es, fr in i18n catalog).
 
 ---
 
 ## Phase 3 — Visual design & assets
 
-- [ ] Reuse design tokens (`bg-background`, `text-foreground`, brand blue) for consistency with app.
-- [ ] **Responsive layout:** stack sections on mobile, multi-column on `md`/`lg`; readable typography and tap targets on small screens.
-- [ ] Hero illustration or screenshot from staging (orders + kitchen).
-- [ ] Light mode default; dark mode support if trivial with existing tokens.
-- [ ] Favicon / OG meta for link previews (`metadata` in layout).
+- [x] Design tokens (`bg-background`, `text-foreground`, brand blue)
+- [x] **Responsive layout:** stack on mobile, grid on `md`/`lg`
+- [x] Hero kitchen-board mock (CSS, no external asset)
+- [x] Dark mode via existing tokens
+- [x] Root `metadata` + OG defaults in `layout.tsx`
 
 ---
 
 ## Phase 4 — i18n & SEO
 
-- [ ] Marketing strings in i18n catalog (`marketing.*`) or static MDX — align with plan 02 locale hook where useful; default pt-BR for anonymous visitors.
-- [ ] `metadata`: title, description, Open Graph, locale.
-- [ ] Optional: `/en` prefix or `?lang=` — only if needed; defer until copy exists in both languages.
+- [x] Marketing strings in i18n catalog (`marketing.*`); default locale pt-BR for anonymous visitors
+- [x] `metadata`: title, description, Open Graph, `lang="pt-BR"`
+- [ ] Optional: `/en` prefix — deferred
 
 ---
 
 ## Phase 5 — Analytics & conversion (optional)
 
-- [ ] UTM-friendly signup links.
-- [ ] Simple event hooks (CTA clicks) — no third-party until privacy policy exists.
-- [ ] Optional waitlist / contact form → API or external form service (out of scope until legal review).
-
----
-
-## Out of scope (v1)
-
-- Full CMS or blog.
-- Custom domain split (marketing `ubuteco.com` vs app `app.…`) — document as future DevOps task.
-
-Note: the **authenticated app** remains desktop-focused (see plan 13); only the **marketing site** requires full responsiveness.
+- [ ] UTM-friendly signup links
+- [ ] Simple event hooks (CTA clicks)
+- [ ] Contact form — out of scope until legal review
 
 ---
 
 ## Definition of done
 
-- [ ] Anonymous visitor at `/` sees a polished landing with clear CTA to `/signup`.
-- [ ] Authenticated user hitting `/` goes to dashboard (no marketing flash).
-- [ ] Marketing pages work without sidebar; app routes unchanged.
-- [ ] Layout verified on mobile (~375px), tablet, and desktop breakpoints.
-- [ ] Plan linked from [README](./README.md).
+- [x] Anonymous visitor at `/` sees landing with CTA to `/signup`
+- [x] Authenticated user at `/` sees dashboard
+- [x] Marketing pages work without sidebar; app routes unchanged
+- [ ] Layout verified on mobile (~375px), tablet, and desktop breakpoints (manual QA)
+- [x] Plan linked from [README](./README.md)
 
 ---
 
 ## References
 
-- `src/app/login/page.tsx`, `src/app/signup/page.tsx` — existing auth UX
-- `src/app/_components/SidebarLayout.tsx` — app shell to exclude from marketing
-- Plan [02-locale-and-currency](./02-locale-and-currency.md) — i18n patterns
-- Plan [03-subscription-plans](./03-subscription-plans.md) — future pricing section
+- `src/app/_components/marketing/LandingPage.tsx`
+- `src/app/login/page.tsx`, `src/app/signup/page.tsx`
+- Plan [02-locale-and-currency](./02-locale-and-currency.md)

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -43,7 +43,7 @@ Ordered by priority. **#3 is deferred to the end** (see note above).
 | 12 | [Appearance — dark mode](./12-appearance-dark-mode.md) | completed | P2 | — |
 | 10 | [Browser document titles](./10-document-titles.md) | not started | P2 | — |
 | 9 | [Frontend performance](./09-frontend-performance.md) | not started | P2 | — |
-| 14 | [Marketing landing page](./14-landing-page.md) | not started | P2 | — |
+| 14 | [Marketing landing page](./14-landing-page.md) | in progress | P2 | — |
 | 3 | [Subscription plans](./03-subscription-plans.md) | not started | **Last** | [API](../../../ubuteco_api/docs/plans/03-subscription-plans.md) |
 
 ## Recent merges (Jun 2026)
@@ -54,9 +54,9 @@ Ordered by priority. **#3 is deferred to the end** (see note above).
 | [11 Inventory UI](./11-inventory-ui.md) | [#26](https://github.com/Sartori-RIA/ubuteco-react/pull/26) | Stock display, adjust panel, `/inventory`, i18n follow-ups |
 | [02 Locale & currency](./02-locale-and-currency.md) | [#27](https://github.com/Sartori-RIA/ubuteco-react/pull/27) | `es`, `fr`, `fr-CA`, `en-CA`; CAD + LATAM pesos; Brazil/Canada/EU timezones; order status UX |
 
-**In progress:** [01 Multi-tenant](./01-multi-tenant.md) (Phases 3–4), [08 API contract & CI/CD](../../../ubuteco_api/docs/plans/08-api-contract-and-ci.md) (OpenAPI drift done; eslint CI pending).
+**In progress:** [01 Multi-tenant](./01-multi-tenant.md) (Phases 3–4), [14 Marketing landing page](./14-landing-page.md).
 
-**Next up:** [10 Document titles](./10-document-titles.md), [09 Frontend performance](./09-frontend-performance.md), [14 Marketing landing page](./14-landing-page.md). **Last:** [03 Subscription plans](./03-subscription-plans.md).
+**Next up:** [10 Document titles](./10-document-titles.md), [09 Frontend performance](./09-frontend-performance.md). **Last:** [03 Subscription plans](./03-subscription-plans.md).
 
 Platform hardening (API): [05-platform-hardening](../../../ubuteco_api/docs/plans/05-platform-hardening.md).
 

--- a/src/app/_components/AuthGuard.tsx
+++ b/src/app/_components/AuthGuard.tsx
@@ -37,11 +37,12 @@ export default function AuthGuard({children}: {children: ReactNode}) {
   const authStatus = useAppSelector((state) => state.auth.status);
   const {canMutateOperationalData, user} = useAuthCapabilities();
 
-  const token = getAuthToken();
-  const isAuthenticated = Boolean(token) || authStatus === "authenticated";
+  const isAuthenticated =
+    ready && (Boolean(getAuthToken()) || authStatus === "authenticated");
+  const marketingShell = isMarketingShellPath(pathname, {ready, authenticated: isAuthenticated});
 
   useEffect(() => {
-    if (!ready || isMarketingShellPath(pathname, isAuthenticated)) return;
+    if (!ready || marketingShell) return;
 
     if (!isAuthenticated) {
       router.replace("/login");
@@ -81,9 +82,9 @@ export default function AuthGuard({children}: {children: ReactNode}) {
     if (user && isDashboardPath(pathname) && !canAccessDashboard(user) && !isSuperAdmin(user)) {
       router.replace("/orders");
     }
-  }, [ready, pathname, router, isAuthenticated, canMutateOperationalData, user]);
+  }, [ready, pathname, router, marketingShell, isAuthenticated, canMutateOperationalData, user]);
 
-  if (isMarketingShellPath(pathname, isAuthenticated)) {
+  if (marketingShell) {
     return <>{children}</>;
   }
 

--- a/src/app/_components/AuthGuard.tsx
+++ b/src/app/_components/AuthGuard.tsx
@@ -3,7 +3,7 @@
 import {ReactNode, useEffect} from "react";
 import {usePathname, useRouter} from "next/navigation";
 import {getAuthToken} from "@/app/_lib/auth-storage";
-import {isAuthPublicPath} from "@/app/_lib/auth-routes";
+import {isMarketingShellPath} from "@/app/_lib/auth-routes";
 import {
   canAccessDashboard,
   canAccessInventory,
@@ -37,11 +37,13 @@ export default function AuthGuard({children}: {children: ReactNode}) {
   const authStatus = useAppSelector((state) => state.auth.status);
   const {canMutateOperationalData, user} = useAuthCapabilities();
 
-  useEffect(() => {
-    if (!ready || isAuthPublicPath(pathname)) return;
+  const token = getAuthToken();
+  const isAuthenticated = Boolean(token) || authStatus === "authenticated";
 
-    const token = getAuthToken();
-    if (!token && authStatus !== "authenticated") {
+  useEffect(() => {
+    if (!ready || isMarketingShellPath(pathname, isAuthenticated)) return;
+
+    if (!isAuthenticated) {
       router.replace("/login");
       return;
     }
@@ -79,9 +81,9 @@ export default function AuthGuard({children}: {children: ReactNode}) {
     if (user && isDashboardPath(pathname) && !canAccessDashboard(user) && !isSuperAdmin(user)) {
       router.replace("/orders");
     }
-  }, [ready, pathname, router, authStatus, canMutateOperationalData, user]);
+  }, [ready, pathname, router, isAuthenticated, canMutateOperationalData, user]);
 
-  if (isAuthPublicPath(pathname)) {
+  if (isMarketingShellPath(pathname, isAuthenticated)) {
     return <>{children}</>;
   }
 
@@ -89,7 +91,7 @@ export default function AuthGuard({children}: {children: ReactNode}) {
     return <Loading/>;
   }
 
-  if (!getAuthToken() && authStatus !== "authenticated") {
+  if (!isAuthenticated) {
     return null;
   }
 

--- a/src/app/_components/SidebarLayout.tsx
+++ b/src/app/_components/SidebarLayout.tsx
@@ -4,7 +4,8 @@ import React, {ReactNode, useState} from "react";
 import {AnimatePresence, motion} from "framer-motion";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faBars, faRightFromBracket, faUser} from "@fortawesome/free-solid-svg-icons";
-import {isAuthPublicPath} from "@/app/_lib/auth-routes";
+import {isMarketingShellPath} from "@/app/_lib/auth-routes";
+import {getAuthToken} from "@/app/_lib/auth-storage";
 import {getVisibleNavGroups} from "@/app/_lib/nav-config";
 import {usePageTitle, useTranslations} from "@/app/_hooks/useTranslations";
 import {userInitials} from "@/app/_lib/user-display";
@@ -25,8 +26,10 @@ export default function SidebarLayout({children}: { children: ReactNode }) {
   const t = useTranslations();
   const pageTitle = usePageTitle();
   const navGroups = getVisibleNavGroups(capabilitiesUser);
+  const authStatus = useAppSelector((state) => state.auth.status);
+  const isAuthenticated = Boolean(getAuthToken()) || authStatus === "authenticated";
 
-  if (isAuthPublicPath(pathname)) {
+  if (isMarketingShellPath(pathname, isAuthenticated)) {
     return <>{children}</>;
   }
 

--- a/src/app/_components/SidebarLayout.tsx
+++ b/src/app/_components/SidebarLayout.tsx
@@ -8,6 +8,7 @@ import {isMarketingShellPath} from "@/app/_lib/auth-routes";
 import {getAuthToken} from "@/app/_lib/auth-storage";
 import {getVisibleNavGroups} from "@/app/_lib/nav-config";
 import {usePageTitle, useTranslations} from "@/app/_hooks/useTranslations";
+import {useClientReady} from "@/app/_hooks/useClientReady";
 import {userInitials} from "@/app/_lib/user-display";
 import {Buttons} from ".";
 import Link from "next/link";
@@ -27,9 +28,11 @@ export default function SidebarLayout({children}: { children: ReactNode }) {
   const pageTitle = usePageTitle();
   const navGroups = getVisibleNavGroups(capabilitiesUser);
   const authStatus = useAppSelector((state) => state.auth.status);
-  const isAuthenticated = Boolean(getAuthToken()) || authStatus === "authenticated";
+  const ready = useClientReady();
+  const isAuthenticated =
+    ready && (Boolean(getAuthToken()) || authStatus === "authenticated");
 
-  if (isMarketingShellPath(pathname, isAuthenticated)) {
+  if (isMarketingShellPath(pathname, {ready, authenticated: isAuthenticated})) {
     return <>{children}</>;
   }
 

--- a/src/app/_components/marketing/LandingPage.tsx
+++ b/src/app/_components/marketing/LandingPage.tsx
@@ -142,13 +142,11 @@ export function LandingPage() {
           <div className="rounded-2xl bg-blue-600 px-6 py-12 text-center text-white sm:px-10 sm:py-14">
             <h2 className="text-2xl font-bold sm:text-3xl">{t("marketing.cta.title")}</h2>
             <p className="mx-auto mt-3 max-w-xl text-blue-100">{t("marketing.cta.subtitle")}</p>
-            <Link href="/signup" className="mt-8 inline-block">
-              <Buttons
-                size="lg"
-                className="rounded-xl bg-white text-blue-700 hover:bg-blue-50 dark:bg-white dark:text-blue-800"
-              >
-                {t("marketing.cta.button")}
-              </Buttons>
+            <Link
+              href="/signup"
+              className="mt-8 inline-flex h-12 items-center justify-center rounded-xl bg-white px-6 text-base font-semibold text-blue-700 shadow-sm transition hover:bg-blue-50"
+            >
+              {t("marketing.cta.button")}
             </Link>
           </div>
         </section>

--- a/src/app/_components/marketing/LandingPage.tsx
+++ b/src/app/_components/marketing/LandingPage.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import {useEffect} from "react";
+import Link from "next/link";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {
+  faBellConcierge,
+  faBookOpen,
+  faFireBurner,
+  faGlobe,
+} from "@fortawesome/free-solid-svg-icons";
+import {Buttons} from "@/app/_components";
+import {MarketingFooter} from "@/app/_components/marketing/MarketingFooter";
+import {MarketingHeader} from "@/app/_components/marketing/MarketingHeader";
+import {useTranslations} from "@/app/_hooks/useTranslations";
+import type {TranslationKey} from "@/app/_lib/i18n";
+
+const FEATURES: Array<{id: string; icon: typeof faBellConcierge; titleKey: TranslationKey; bodyKey: TranslationKey}> =
+  [
+    {
+      id: "operations",
+      icon: faBellConcierge,
+      titleKey: "marketing.features.operations.title",
+      bodyKey: "marketing.features.operations.body",
+    },
+    {
+      id: "catalog",
+      icon: faBookOpen,
+      titleKey: "marketing.features.catalog.title",
+      bodyKey: "marketing.features.catalog.body",
+    },
+    {
+      id: "kitchen",
+      icon: faFireBurner,
+      titleKey: "marketing.features.kitchen.title",
+      bodyKey: "marketing.features.kitchen.body",
+    },
+    {
+      id: "settings",
+      icon: faGlobe,
+      titleKey: "marketing.features.settings.title",
+      bodyKey: "marketing.features.settings.body",
+    },
+  ];
+
+export function LandingPage() {
+  const t = useTranslations();
+
+  useEffect(() => {
+    document.title = t("marketing.meta.title");
+  }, [t]);
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background text-foreground">
+      <MarketingHeader/>
+
+      <main className="flex-1">
+        <section className="mx-auto max-w-6xl px-4 py-16 sm:px-6 sm:py-24 lg:py-28">
+          <div className="grid items-center gap-12 lg:grid-cols-2 lg:gap-16">
+            <div className="space-y-6">
+              <h1 className="text-4xl font-bold tracking-tight sm:text-5xl lg:text-[2.75rem] lg:leading-tight">
+                {t("marketing.hero.title")}
+              </h1>
+              <p className="max-w-xl text-lg text-muted">{t("marketing.hero.subtitle")}</p>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                <Link href="/signup">
+                  <Buttons size="lg" className="w-full rounded-xl sm:w-auto">
+                    {t("marketing.hero.ctaPrimary")}
+                  </Buttons>
+                </Link>
+                <a
+                  href="#features"
+                  className="inline-flex h-11 items-center justify-center rounded-xl border border-border bg-surface px-6 text-sm font-medium hover:bg-surface-muted"
+                >
+                  {t("marketing.hero.ctaSecondary")}
+                </a>
+              </div>
+            </div>
+
+            <div className="relative mx-auto w-full max-w-lg lg:max-w-none">
+              <div className="rounded-2xl border border-border bg-surface p-6 shadow-xl">
+                <div className="mb-4 flex items-center justify-between text-xs font-medium text-muted">
+                  <span>{t("nav.kitchen")}</span>
+                  <span className="inline-flex items-center gap-1.5 text-emerald-600 dark:text-emerald-400">
+                    <span className="h-2 w-2 rounded-full bg-emerald-500"/>
+                    Live
+                  </span>
+                </div>
+                <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+                  {["Awaiting", "Cooking", "Ready", "Done"].map((col, index) => (
+                    <div key={col} className="rounded-xl border border-border bg-surface-muted p-3">
+                      <p className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-muted">{col}</p>
+                      {index === 0 ? (
+                        <div className="rounded-lg border border-blue-200 bg-blue-50 p-2 text-xs dark:border-blue-800 dark:bg-blue-950/40">
+                          <p className="font-semibold">House Burger</p>
+                          <p className="text-muted">Table 4 · ×2</p>
+                        </div>
+                      ) : (
+                        <p className="py-4 text-center text-[10px] text-muted">—</p>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="border-y border-border bg-surface-muted">
+          <div className="mx-auto max-w-3xl px-4 py-14 text-center sm:px-6 sm:py-16">
+            <h2 className="text-2xl font-bold sm:text-3xl">{t("marketing.problem.title")}</h2>
+            <p className="mt-4 text-base leading-relaxed text-muted sm:text-lg">{t("marketing.problem.body")}</p>
+          </div>
+        </section>
+
+        <section id="features" className="mx-auto max-w-6xl px-4 py-16 sm:px-6 sm:py-20">
+          <h2 className="text-center text-2xl font-bold sm:text-3xl">{t("marketing.features.title")}</h2>
+          <div className="mt-10 grid gap-6 sm:grid-cols-2 lg:gap-8">
+            {FEATURES.map(({id, icon, titleKey, bodyKey}) => (
+              <article
+                key={id}
+                className="rounded-2xl border border-border bg-surface p-6 shadow-sm transition hover:border-blue-300 dark:hover:border-blue-700"
+              >
+                <span className="inline-flex h-11 w-11 items-center justify-center rounded-xl bg-blue-600 text-white">
+                  <FontAwesomeIcon icon={icon} className="h-5 w-5"/>
+                </span>
+                <h3 className="mt-4 text-lg font-semibold">{t(titleKey)}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-muted">{t(bodyKey)}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="border-t border-border bg-surface-muted">
+          <div className="mx-auto max-w-3xl px-4 py-14 text-center sm:px-6">
+            <h2 className="text-xl font-semibold sm:text-2xl">{t("marketing.proof.title")}</h2>
+            <p className="mt-3 text-muted">{t("marketing.proof.body")}</p>
+          </div>
+        </section>
+
+        <section className="mx-auto max-w-6xl px-4 py-16 sm:px-6 sm:py-20">
+          <div className="rounded-2xl bg-blue-600 px-6 py-12 text-center text-white sm:px-10 sm:py-14">
+            <h2 className="text-2xl font-bold sm:text-3xl">{t("marketing.cta.title")}</h2>
+            <p className="mx-auto mt-3 max-w-xl text-blue-100">{t("marketing.cta.subtitle")}</p>
+            <Link href="/signup" className="mt-8 inline-block">
+              <Buttons
+                size="lg"
+                className="rounded-xl bg-white text-blue-700 hover:bg-blue-50 dark:bg-white dark:text-blue-800"
+              >
+                {t("marketing.cta.button")}
+              </Buttons>
+            </Link>
+          </div>
+        </section>
+      </main>
+
+      <MarketingFooter/>
+    </div>
+  );
+}

--- a/src/app/_components/marketing/LegalPageLayout.tsx
+++ b/src/app/_components/marketing/LegalPageLayout.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import Link from "next/link";
+import {useEffect} from "react";
+import {MarketingFooter} from "@/app/_components/marketing/MarketingFooter";
+import {MarketingHeader} from "@/app/_components/marketing/MarketingHeader";
+import {useOrganizationSettings} from "@/app/_hooks/useOrganizationSettings";
+import type {LegalDocument} from "@/app/_lib/legal/types";
+import {useTranslations} from "@/app/_hooks/useTranslations";
+
+type Props = {
+  content: LegalDocument;
+};
+
+export function LegalPageLayout({content}: Props) {
+  const t = useTranslations();
+
+  useEffect(() => {
+    document.title = `${content.title} | uButeco`;
+  }, [content.title]);
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background text-foreground">
+      <MarketingHeader/>
+
+      <main className="flex-1">
+        <article className="mx-auto max-w-3xl px-4 py-12 sm:px-6 sm:py-16">
+          <Link
+            href="/"
+            className="text-sm font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+          >
+            ← {t("legal.backToHome")}
+          </Link>
+
+          <header className="mt-6 border-b border-border pb-8">
+            <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">{content.title}</h1>
+            <p className="mt-3 text-sm text-muted">
+              {t("legal.lastUpdated")}: {content.lastUpdated}
+            </p>
+            <p className="mt-4 text-base leading-relaxed text-muted">{content.intro}</p>
+          </header>
+
+          <div className="mt-10 space-y-10">
+            {content.sections.map((section) => (
+              <section key={section.title}>
+                <h2 className="text-lg font-semibold text-foreground">{section.title}</h2>
+                <div className="mt-3 space-y-3">
+                  {section.paragraphs.map((paragraph) => (
+                    <p key={paragraph} className="text-base leading-relaxed text-muted">
+                      {paragraph}
+                    </p>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        </article>
+      </main>
+
+      <MarketingFooter/>
+    </div>
+  );
+}

--- a/src/app/_components/marketing/MarketingFooter.tsx
+++ b/src/app/_components/marketing/MarketingFooter.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import Link from "next/link";
+import {useTranslations} from "@/app/_hooks/useTranslations";
+
+export function MarketingFooter() {
+  const t = useTranslations();
+
+  return (
+    <footer className="border-t border-border bg-surface-muted">
+      <div className="mx-auto flex max-w-6xl flex-col gap-6 px-4 py-10 sm:px-6 md:flex-row md:items-center md:justify-between">
+        <p className="text-sm text-muted">{t("marketing.footer.tagline")}</p>
+        <nav className="flex flex-wrap gap-x-6 gap-y-2 text-sm font-medium">
+          <Link href="/login" className="text-foreground hover:text-blue-600 dark:hover:text-blue-400">
+            {t("marketing.footer.signIn")}
+          </Link>
+          <Link href="/signup" className="text-foreground hover:text-blue-600 dark:hover:text-blue-400">
+            {t("marketing.footer.signUp")}
+          </Link>
+          <span className="cursor-default text-muted">{t("marketing.footer.contact")}</span>
+        </nav>
+      </div>
+    </footer>
+  );
+}

--- a/src/app/_components/marketing/MarketingFooter.tsx
+++ b/src/app/_components/marketing/MarketingFooter.tsx
@@ -17,7 +17,12 @@ export function MarketingFooter() {
           <Link href="/signup" className="text-foreground hover:text-blue-600 dark:hover:text-blue-400">
             {t("marketing.footer.signUp")}
           </Link>
-          <span className="cursor-default text-muted">{t("marketing.footer.contact")}</span>
+          <Link href="/terms" className="text-foreground hover:text-blue-600 dark:hover:text-blue-400">
+            {t("marketing.footer.terms")}
+          </Link>
+          <Link href="/privacy" className="text-foreground hover:text-blue-600 dark:hover:text-blue-400">
+            {t("marketing.footer.privacy")}
+          </Link>
         </nav>
       </div>
     </footer>

--- a/src/app/_components/marketing/MarketingHeader.tsx
+++ b/src/app/_components/marketing/MarketingHeader.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import Link from "next/link";
+import {Buttons} from "@/app/_components";
+import {useTranslations} from "@/app/_hooks/useTranslations";
+
+export function MarketingHeader() {
+  const t = useTranslations();
+
+  return (
+    <header className="sticky top-0 z-50 border-b border-border bg-surface/95 backdrop-blur supports-[backdrop-filter]:bg-surface/80">
+      <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4 sm:px-6">
+        <Link href="/" className="text-lg font-bold tracking-tight text-foreground">
+          {t("common.appName")}
+        </Link>
+        <nav className="flex items-center gap-2 sm:gap-3">
+          <Link
+            href="/login"
+            className="rounded-xl px-3 py-2 text-sm font-medium text-foreground hover:bg-surface-muted"
+          >
+            {t("marketing.header.signIn")}
+          </Link>
+          <Link href="/signup">
+            <Buttons size="sm" className="rounded-xl">
+              {t("marketing.header.startFree")}
+            </Buttons>
+          </Link>
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/src/app/_lib/auth-routes.test.ts
+++ b/src/app/_lib/auth-routes.test.ts
@@ -8,10 +8,15 @@ describe("auth-routes", () => {
   });
 
   it("skips app shell for auth routes and logged-out home", () => {
-    expect(isMarketingShellPath("/login", false)).toBe(true);
-    expect(isMarketingShellPath("/login", true)).toBe(true);
-    expect(isMarketingShellPath("/", false)).toBe(true);
-    expect(isMarketingShellPath("/", true)).toBe(false);
-    expect(isMarketingShellPath("/orders", false)).toBe(false);
+    expect(isMarketingShellPath("/login", {ready: true, authenticated: false})).toBe(true);
+    expect(isMarketingShellPath("/login", {ready: true, authenticated: true})).toBe(true);
+    expect(isMarketingShellPath("/", {ready: true, authenticated: false})).toBe(true);
+    expect(isMarketingShellPath("/", {ready: true, authenticated: true})).toBe(false);
+    expect(isMarketingShellPath("/orders", {ready: true, authenticated: false})).toBe(false);
+  });
+
+  it("treats home as marketing shell until client is ready", () => {
+    expect(isMarketingShellPath("/", {ready: false, authenticated: false})).toBe(true);
+    expect(isMarketingShellPath("/", {ready: false, authenticated: true})).toBe(true);
   });
 });

--- a/src/app/_lib/auth-routes.test.ts
+++ b/src/app/_lib/auth-routes.test.ts
@@ -13,6 +13,8 @@ describe("auth-routes", () => {
     expect(isMarketingShellPath("/", {ready: true, authenticated: false})).toBe(true);
     expect(isMarketingShellPath("/", {ready: true, authenticated: true})).toBe(false);
     expect(isMarketingShellPath("/orders", {ready: true, authenticated: false})).toBe(false);
+    expect(isMarketingShellPath("/terms", {ready: true, authenticated: true})).toBe(true);
+    expect(isMarketingShellPath("/privacy", {ready: true, authenticated: false})).toBe(true);
   });
 
   it("treats home as marketing shell until client is ready", () => {

--- a/src/app/_lib/auth-routes.test.ts
+++ b/src/app/_lib/auth-routes.test.ts
@@ -1,0 +1,17 @@
+import {describe, expect, it} from "vitest";
+import {isAuthPublicPath, isMarketingShellPath} from "@/app/_lib/auth-routes";
+
+describe("auth-routes", () => {
+  it("marks auth pages as public", () => {
+    expect(isAuthPublicPath("/login")).toBe(true);
+    expect(isAuthPublicPath("/orders")).toBe(false);
+  });
+
+  it("skips app shell for auth routes and logged-out home", () => {
+    expect(isMarketingShellPath("/login", false)).toBe(true);
+    expect(isMarketingShellPath("/login", true)).toBe(true);
+    expect(isMarketingShellPath("/", false)).toBe(true);
+    expect(isMarketingShellPath("/", true)).toBe(false);
+    expect(isMarketingShellPath("/orders", false)).toBe(false);
+  });
+});

--- a/src/app/_lib/auth-routes.ts
+++ b/src/app/_lib/auth-routes.ts
@@ -8,3 +8,9 @@ export const AUTH_PUBLIC_PATHS = [
 export function isAuthPublicPath(pathname: string): boolean {
   return (AUTH_PUBLIC_PATHS as readonly string[]).includes(pathname);
 }
+
+/** Routes that render without the authenticated app shell (sidebar). */
+export function isMarketingShellPath(pathname: string, authenticated: boolean): boolean {
+  if (isAuthPublicPath(pathname)) return true;
+  return pathname === "/" && !authenticated;
+}

--- a/src/app/_lib/auth-routes.ts
+++ b/src/app/_lib/auth-routes.ts
@@ -5,6 +5,8 @@ export const AUTH_PUBLIC_PATHS = [
   "/reset-password",
 ] as const;
 
+export const MARKETING_PUBLIC_PATHS = ["/terms", "/privacy"] as const;
+
 export type AuthShellSession = {
   ready: boolean;
   authenticated: boolean;
@@ -17,6 +19,7 @@ export function isAuthPublicPath(pathname: string): boolean {
 /** Routes that render without the authenticated app shell (sidebar). */
 export function isMarketingShellPath(pathname: string, session: AuthShellSession): boolean {
   if (isAuthPublicPath(pathname)) return true;
+  if ((MARKETING_PUBLIC_PATHS as readonly string[]).includes(pathname)) return true;
   if (pathname === "/") {
     if (!session.ready) return true;
     return !session.authenticated;

--- a/src/app/_lib/auth-routes.ts
+++ b/src/app/_lib/auth-routes.ts
@@ -5,12 +5,21 @@ export const AUTH_PUBLIC_PATHS = [
   "/reset-password",
 ] as const;
 
+export type AuthShellSession = {
+  ready: boolean;
+  authenticated: boolean;
+};
+
 export function isAuthPublicPath(pathname: string): boolean {
   return (AUTH_PUBLIC_PATHS as readonly string[]).includes(pathname);
 }
 
 /** Routes that render without the authenticated app shell (sidebar). */
-export function isMarketingShellPath(pathname: string, authenticated: boolean): boolean {
+export function isMarketingShellPath(pathname: string, session: AuthShellSession): boolean {
   if (isAuthPublicPath(pathname)) return true;
-  return pathname === "/" && !authenticated;
+  if (pathname === "/") {
+    if (!session.ready) return true;
+    return !session.authenticated;
+  }
+  return false;
 }

--- a/src/app/_lib/i18n/messages/en.ts
+++ b/src/app/_lib/i18n/messages/en.ts
@@ -537,6 +537,63 @@ const en: MessageCatalog = {
       closed: "Kitchen is closed — new items are not processed.",
     },
   },
+  marketing: {
+    meta: {
+      title: "uButeco — Restaurant & bar management",
+      description:
+        "Multi-tenant SaaS for bars and restaurants: orders, live kitchen queue, catalog, and regional settings.",
+    },
+    header: {
+      signIn: "Sign in",
+      startFree: "Start free",
+    },
+    hero: {
+      title: "Run your bar or restaurant without spreadsheet chaos",
+      subtitle:
+        "Orders, kitchen queue, menu catalog, and staff roles — one platform built for multi-location hospitality teams.",
+      ctaPrimary: "Create free account",
+      ctaSecondary: "See how it works",
+    },
+    problem: {
+      title: "Floor, kitchen, and back office on the same page",
+      body:
+        "Stop juggling paper tickets, WhatsApp orders, and disconnected spreadsheets. uButeco keeps service, kitchen, and catalog in sync — with real-time updates when a dish hits the line.",
+    },
+    features: {
+      title: "Everything your team needs day to day",
+      operations: {
+        title: "Operations",
+        body: "Open orders, tables, discounts, and role-based access for waiters, kitchen, and admins.",
+      },
+      catalog: {
+        title: "Menu & catalog",
+        body: "Beers, wines, drinks, dishes, and stock-aware products — searchable and org-scoped.",
+      },
+      kitchen: {
+        title: "Live kitchen",
+        body: "WebSocket kitchen queue: new dishes appear instantly, statuses flow awaiting → cooking → ready.",
+      },
+      settings: {
+        title: "Regional settings",
+        body: "Locale, currency, and timezone per organization — ready for Brazil, Canada, and LATAM.",
+      },
+    },
+    proof: {
+      title: "Built for bars & restaurants",
+      body: "Open-source stack, multi-tenant by design, and shaped by real service workflows — not generic retail software.",
+    },
+    cta: {
+      title: "Ready to simplify service?",
+      subtitle: "Create your organization and invite your team in minutes.",
+      button: "Get started — it's free",
+    },
+    footer: {
+      signIn: "Sign in",
+      signUp: "Create account",
+      contact: "Contact",
+      tagline: "uButeco — hospitality operations, simplified.",
+    },
+  },
 };
 
 export default en;

--- a/src/app/_lib/i18n/messages/en.ts
+++ b/src/app/_lib/i18n/messages/en.ts
@@ -590,9 +590,16 @@ const en: MessageCatalog = {
     footer: {
       signIn: "Sign in",
       signUp: "Create account",
-      contact: "Contact",
+      terms: "Terms of Use",
+      privacy: "Privacy Policy",
       tagline: "uButeco — hospitality operations, simplified.",
     },
+  },
+  legal: {
+    backToHome: "Back to home",
+    lastUpdated: "Last updated",
+    signUpNoticePrefix: "By creating an account, you agree to our",
+    signUpNoticeAnd: "and",
   },
 };
 

--- a/src/app/_lib/i18n/messages/es.ts
+++ b/src/app/_lib/i18n/messages/es.ts
@@ -539,6 +539,60 @@ const es: MessageCatalog = {
       closed: "Cozinha fechada — novos itens não são processados.",
     },
   },
+  marketing: {
+    meta: {
+      title: "uButeco — Gestión para bares y restaurantes",
+      description:
+        "SaaS multi-tenant para bares y restaurantes: pedidos, cocina en tiempo real, catálogo y ajustes regionales.",
+    },
+    header: {signIn: "Iniciar sesión", startFree: "Empezar gratis"},
+    hero: {
+      title: "Gestiona tu bar o restaurante sin caos en hojas de cálculo",
+      subtitle:
+        "Pedidos, cocina, catálogo y roles del equipo — una plataforma para operaciones de hospitality.",
+      ctaPrimary: "Crear cuenta gratis",
+      ctaSecondary: "Ver cómo funciona",
+    },
+    problem: {
+      title: "Salón, cocina y gestión en la misma página",
+      body:
+        "Deja de perder tickets y pedidos en WhatsApp. uButeco mantiene servicio, cocina y catálogo sincronizados en tiempo real.",
+    },
+    features: {
+      title: "Todo lo que tu equipo usa a diario",
+      operations: {
+        title: "Operaciones",
+        body: "Pedidos abiertos, mesas, descuentos y acceso por rol.",
+      },
+      catalog: {
+        title: "Menú y catálogo",
+        body: "Cervezas, vinos, bebidas, platos y stock — búsqueda por establecimiento.",
+      },
+      kitchen: {
+        title: "Cocina en vivo",
+        body: "Cola WebSocket: platos nuevos al instante, estados en flujo.",
+      },
+      settings: {
+        title: "Ajustes regionales",
+        body: "Locale, moneda y zona horaria por organización.",
+      },
+    },
+    proof: {
+      title: "Hecho para bares y restaurantes",
+      body: "Stack open-source y multi-tenant, diseñado para servicio real.",
+    },
+    cta: {
+      title: "¿Listo para simplificar el servicio?",
+      subtitle: "Crea tu organización e invita al equipo en minutos.",
+      button: "Empezar — es gratis",
+    },
+    footer: {
+      signIn: "Iniciar sesión",
+      signUp: "Crear cuenta",
+      contact: "Contacto",
+      tagline: "uButeco — operaciones de hospitality, simplificadas.",
+    },
+  },
 };
 
 export default es;

--- a/src/app/_lib/i18n/messages/es.ts
+++ b/src/app/_lib/i18n/messages/es.ts
@@ -589,9 +589,16 @@ const es: MessageCatalog = {
     footer: {
       signIn: "Iniciar sesión",
       signUp: "Crear cuenta",
-      contact: "Contacto",
+      terms: "Términos de uso",
+      privacy: "Política de privacidad",
       tagline: "uButeco — operaciones de hospitality, simplificadas.",
     },
+  },
+  legal: {
+    backToHome: "Volver al inicio",
+    lastUpdated: "Última actualización",
+    signUpNoticePrefix: "Al crear una cuenta, aceptas los",
+    signUpNoticeAnd: "y la",
   },
 };
 

--- a/src/app/_lib/i18n/messages/fr.ts
+++ b/src/app/_lib/i18n/messages/fr.ts
@@ -226,9 +226,16 @@ const fr: MessageCatalog = {
     footer: {
       signIn: "Se connecter",
       signUp: "Créer un compte",
-      contact: "Contact",
+      terms: "Conditions d'utilisation",
+      privacy: "Politique de confidentialité",
       tagline: "uButeco — opérations hospitality, simplifiées.",
     },
+  },
+  legal: {
+    backToHome: "Retour à l'accueil",
+    lastUpdated: "Dernière mise à jour",
+    signUpNoticePrefix: "En créant un compte, vous acceptez les",
+    signUpNoticeAnd: "et la",
   },
 };
 

--- a/src/app/_lib/i18n/messages/fr.ts
+++ b/src/app/_lib/i18n/messages/fr.ts
@@ -176,6 +176,60 @@ const fr: MessageCatalog = {
       openOrders: "Commandes ouvertes",
     },
   },
+  marketing: {
+    meta: {
+      title: "uButeco — Gestion pour bars et restaurants",
+      description:
+        "SaaS multi-tenant pour bars et restaurants : commandes, cuisine en direct, catalogue et réglages régionaux.",
+    },
+    header: {signIn: "Se connecter", startFree: "Commencer gratuitement"},
+    hero: {
+      title: "Gérez votre bar ou restaurant sans chaos",
+      subtitle:
+        "Commandes, file cuisine, catalogue et rôles — une plateforme pour l'hospitality multi-sites.",
+      ctaPrimary: "Créer un compte gratuit",
+      ctaSecondary: "Voir comment ça marche",
+    },
+    problem: {
+      title: "Salle, cuisine et gestion sur la même page",
+      body:
+        "Fini les tickets perdus et les commandes WhatsApp. uButeco synchronise service, cuisine et catalogue en temps réel.",
+    },
+    features: {
+      title: "Tout ce dont votre équipe a besoin",
+      operations: {
+        title: "Opérations",
+        body: "Commandes ouvertes, tables, remises et accès par rôle.",
+      },
+      catalog: {
+        title: "Menu et catalogue",
+        body: "Bières, vins, boissons, plats et stock — recherche par établissement.",
+      },
+      kitchen: {
+        title: "Cuisine en direct",
+        body: "File WebSocket : nouveaux plats instantanément, statuts en flux.",
+      },
+      settings: {
+        title: "Réglages régionaux",
+        body: "Locale, devise et fuseau par organisation.",
+      },
+    },
+    proof: {
+      title: "Conçu pour bars et restaurants",
+      body: "Stack open-source et multi-tenant, pensé pour le service réel.",
+    },
+    cta: {
+      title: "Prêt à simplifier le service ?",
+      subtitle: "Créez votre organisation et invitez l'équipe en minutes.",
+      button: "Commencer — c'est gratuit",
+    },
+    footer: {
+      signIn: "Se connecter",
+      signUp: "Créer un compte",
+      contact: "Contact",
+      tagline: "uButeco — opérations hospitality, simplifiées.",
+    },
+  },
 };
 
 export default fr;

--- a/src/app/_lib/i18n/messages/pt-BR.ts
+++ b/src/app/_lib/i18n/messages/pt-BR.ts
@@ -592,9 +592,16 @@ const ptBR: MessageCatalog = {
     footer: {
       signIn: "Entrar",
       signUp: "Criar conta",
-      contact: "Contato",
+      terms: "Termos de Uso",
+      privacy: "Política de Privacidade",
       tagline: "uButeco — operação de hospitality, simplificada.",
     },
+  },
+  legal: {
+    backToHome: "Voltar ao início",
+    lastUpdated: "Última atualização",
+    signUpNoticePrefix: "Ao criar uma conta, você concorda com os",
+    signUpNoticeAnd: "e a",
   },
 };
 

--- a/src/app/_lib/i18n/messages/pt-BR.ts
+++ b/src/app/_lib/i18n/messages/pt-BR.ts
@@ -539,6 +539,63 @@ const ptBR: MessageCatalog = {
       closed: "Cozinha fechada — novos itens não são processados.",
     },
   },
+  marketing: {
+    meta: {
+      title: "uButeco — Gestão para bares e restaurantes",
+      description:
+        "SaaS multi-tenant para bares e restaurantes: pedidos, fila da cozinha em tempo real, cardápio e configurações regionais.",
+    },
+    header: {
+      signIn: "Entrar",
+      startFree: "Começar grátis",
+    },
+    hero: {
+      title: "Gerencie seu bar ou restaurante sem planilha caótica",
+      subtitle:
+        "Pedidos, fila da cozinha, cardápio e papéis da equipe — uma plataforma feita para operações de hospitality multi-unidade.",
+      ctaPrimary: "Criar conta grátis",
+      ctaSecondary: "Ver como funciona",
+    },
+    problem: {
+      title: "Salão, cozinha e gestão na mesma página",
+      body:
+        "Chega de anotar pedido no WhatsApp e perder ticket de cozinha. O uButeco mantém atendimento, cozinha e catálogo sincronizados — com atualização em tempo real quando um prato entra na fila.",
+    },
+    features: {
+      title: "Tudo que sua equipe usa no dia a dia",
+      operations: {
+        title: "Operação",
+        body: "Pedidos abertos, mesas, descontos e acesso por papel — garçom, cozinha e admin.",
+      },
+      catalog: {
+        title: "Cardápio e catálogo",
+        body: "Cervejas, vinhos, drinks, pratos e produtos com estoque — busca e escopo por estabelecimento.",
+      },
+      kitchen: {
+        title: "Cozinha ao vivo",
+        body: "Fila via WebSocket: pratos novos aparecem na hora, status segue aguardando → preparo → pronto.",
+      },
+      settings: {
+        title: "Configurações regionais",
+        body: "Locale, moeda e fuso por organização — pronto para Brasil, Canadá e LATAM.",
+      },
+    },
+    proof: {
+      title: "Feito para bares e restaurantes",
+      body: "Stack open-source, multi-tenant de propósito, moldado por fluxos reais de serviço — não software genérico de varejo.",
+    },
+    cta: {
+      title: "Pronto para simplificar o serviço?",
+      subtitle: "Crie sua organização e convide a equipe em minutos.",
+      button: "Começar — é grátis",
+    },
+    footer: {
+      signIn: "Entrar",
+      signUp: "Criar conta",
+      contact: "Contato",
+      tagline: "uButeco — operação de hospitality, simplificada.",
+    },
+  },
 };
 
 export default ptBR;

--- a/src/app/_lib/i18n/messages/types.ts
+++ b/src/app/_lib/i18n/messages/types.ts
@@ -549,9 +549,16 @@ export type MessageCatalog = {
     footer: {
       signIn: string;
       signUp: string;
-      contact: string;
+      terms: string;
+      privacy: string;
       tagline: string;
     };
+  };
+  legal: {
+    backToHome: string;
+    lastUpdated: string;
+    signUpNoticePrefix: string;
+    signUpNoticeAnd: string;
   };
 };
 

--- a/src/app/_lib/i18n/messages/types.ts
+++ b/src/app/_lib/i18n/messages/types.ts
@@ -511,6 +511,48 @@ export type MessageCatalog = {
       closed: string;
     };
   };
+  marketing: {
+    meta: {
+      title: string;
+      description: string;
+    };
+    header: {
+      signIn: string;
+      startFree: string;
+    };
+    hero: {
+      title: string;
+      subtitle: string;
+      ctaPrimary: string;
+      ctaSecondary: string;
+    };
+    problem: {
+      title: string;
+      body: string;
+    };
+    features: {
+      title: string;
+      operations: {title: string; body: string};
+      catalog: {title: string; body: string};
+      kitchen: {title: string; body: string};
+      settings: {title: string; body: string};
+    };
+    proof: {
+      title: string;
+      body: string;
+    };
+    cta: {
+      title: string;
+      subtitle: string;
+      button: string;
+    };
+    footer: {
+      signIn: string;
+      signUp: string;
+      contact: string;
+      tagline: string;
+    };
+  };
 };
 
 type JoinKeys<P extends string, K extends string> = P extends "" ? K : `${P}.${K}`;

--- a/src/app/_lib/legal/index.ts
+++ b/src/app/_lib/legal/index.ts
@@ -1,0 +1,21 @@
+import {DEFAULT_LOCALE} from "@/app/_lib/organization-settings";
+import privacyEn from "@/app/_lib/legal/privacy/en";
+import privacyPtBR from "@/app/_lib/legal/privacy/pt-BR";
+import termsEn from "@/app/_lib/legal/terms/en";
+import termsPtBR from "@/app/_lib/legal/terms/pt-BR";
+import type {LegalDocument, LegalDocumentKind} from "@/app/_lib/legal/types";
+
+const TERMS: Record<string, LegalDocument> = {
+  "pt-BR": termsPtBR,
+  en: termsEn,
+};
+
+const PRIVACY: Record<string, LegalDocument> = {
+  "pt-BR": privacyPtBR,
+  en: privacyEn,
+};
+
+export function getLegalDocument(kind: LegalDocumentKind, locale: string): LegalDocument {
+  const catalog = kind === "terms" ? TERMS : PRIVACY;
+  return catalog[locale] ?? catalog[DEFAULT_LOCALE] ?? catalog.en;
+}

--- a/src/app/_lib/legal/privacy/en.ts
+++ b/src/app/_lib/legal/privacy/en.ts
@@ -1,0 +1,91 @@
+import type {LegalDocument} from "@/app/_lib/legal/types";
+
+const privacy: LegalDocument = {
+  title: "Privacy Policy",
+  lastUpdated: "June 10, 2026",
+  intro:
+    "This Privacy Policy explains how uButeco processes personal data of users and operational data of establishments, in line with Brazil's LGPD (Law No. 13.709/2018) and other applicable rules.",
+  sections: [
+    {
+      title: "1. Controller and contact",
+      paragraphs: [
+        "uButeco acts as controller for personal data processed for registration, authentication, support, and platform operation.",
+        "To exercise privacy rights or ask questions, use the contact channel listed on the site or in the app footer.",
+      ],
+    },
+    {
+      title: "2. Data we collect",
+      paragraphs: [
+        "Registration data: name, email, password (stored hashed), role, and organization link.",
+        "Establishment data: business name, phone, logo, regional settings (locale, currency, timezone), and operational status.",
+        "Operational data: orders, line items, tables, stock movements, and logs required to run the service.",
+        "Technical data: access logs, IP address, session identifiers, auth tokens, and device/browser information for security and diagnostics.",
+      ],
+    },
+    {
+      title: "3. Purposes and legal bases",
+      paragraphs: [
+        "Provide the subscribed service (contract performance).",
+        "Authenticate users, enforce permissions, and isolate tenant data (legitimate interest and security).",
+        "Improve stability and prevent fraud or abuse (legitimate interest).",
+        "Comply with legal obligations and lawful requests from authorities.",
+        "Transactional communications about your account. Direct marketing, if any, will rely on consent or opt-out as required by law.",
+      ],
+    },
+    {
+      title: "4. Sharing",
+      paragraphs: [
+        "We do not sell personal data. We share data only with infrastructure providers needed to operate the service (hosting, database, transactional email, search indexing) under appropriate safeguards.",
+        "Data may be disclosed when required by law or to protect rights, safety, and integrity of the service and users.",
+      ],
+    },
+    {
+      title: "5. Retention and deletion",
+      paragraphs: [
+        "We retain data while the account is active and as needed for the purposes above, legal obligations, dispute resolution, and security backups.",
+        "After account deletion, personal data is deleted or anonymized when no legal basis for retention remains, subject to limited backup retention.",
+      ],
+    },
+    {
+      title: "6. Security",
+      paragraphs: [
+        "We apply technical and organizational measures such as HTTPS, role-based access, API multi-tenant isolation, dependency auditing, and secure development practices.",
+        "No system is completely risk-free. If a relevant personal data breach occurs, we will take mitigation and notification steps as required by LGPD.",
+      ],
+    },
+    {
+      title: "7. Your rights",
+      paragraphs: [
+        "You may request confirmation of processing, access, correction, anonymization, portability, deletion of unnecessary data, information on sharing, and withdrawal of consent where applicable.",
+        "Requests are handled within a reasonable timeframe; identity verification may be required.",
+      ],
+    },
+    {
+      title: "8. Cookies and local storage",
+      paragraphs: [
+        "We use browser local storage for session tokens (JWT) and UI preferences (e.g. light/dark theme) required for authenticated use.",
+        "This version does not use third-party advertising cookies. Analytics tools, if added later, will be described here with consent options when required.",
+      ],
+    },
+    {
+      title: "9. International transfers",
+      paragraphs: [
+        "Infrastructure or subprocessors may be located outside Brazil. In those cases we apply LGPD-compatible safeguards such as standard contractual clauses or adequate protection levels.",
+      ],
+    },
+    {
+      title: "10. Children",
+      paragraphs: [
+        "The service targets businesses and their staff. We do not knowingly collect data from individuals under 18 for standalone registration.",
+      ],
+    },
+    {
+      title: "11. Policy updates",
+      paragraphs: [
+        "This policy may be updated; the revision date appears at the top. Material changes may be communicated by email or in-app notice.",
+      ],
+    },
+  ],
+};
+
+export default privacy;

--- a/src/app/_lib/legal/privacy/pt-BR.ts
+++ b/src/app/_lib/legal/privacy/pt-BR.ts
@@ -1,0 +1,91 @@
+import type {LegalDocument} from "@/app/_lib/legal/types";
+
+const privacy: LegalDocument = {
+  title: "Política de Privacidade",
+  lastUpdated: "10 de junho de 2026",
+  intro:
+    "Esta Política de Privacidade descreve como o uButeco trata dados pessoais de usuários e dados operacionais de estabelecimentos, em conformidade com a Lei Geral de Proteção de Dados (LGPD — Lei nº 13.709/2018) e demais normas aplicáveis.",
+  sections: [
+    {
+      title: "1. Controlador e contato",
+      paragraphs: [
+        "O uButeco atua como controlador dos dados pessoais tratados para cadastro, autenticação, suporte e operação da plataforma.",
+        "Para exercer direitos previstos na LGPD ou esclarecer dúvidas sobre privacidade, utilize o canal de contato indicado no site ou na aplicação (seção Contato no rodapé).",
+      ],
+    },
+    {
+      title: "2. Dados que coletamos",
+      paragraphs: [
+        "Dados de cadastro: nome, e-mail, senha (armazenada de forma criptografada), papel de acesso e vínculo com a organização.",
+        "Dados do estabelecimento: nome comercial, telefone, logo, configurações regionais (idioma, moeda, fuso horário) e status operacional.",
+        "Dados operacionais: pedidos, itens, mesas, movimentações de estoque, registros de atividade necessários ao funcionamento do serviço.",
+        "Dados técnicos: logs de acesso, endereço IP, identificadores de sessão, tokens de autenticação e informações de dispositivo/navegador para segurança e diagnóstico.",
+      ],
+    },
+    {
+      title: "3. Finalidades e bases legais",
+      paragraphs: [
+        "Prestar o serviço contratado (execução de contrato ou procedimentos preliminares).",
+        "Autenticar usuários, aplicar permissões e isolar dados entre organizações (legítimo interesse e segurança).",
+        "Melhorar estabilidade, prevenir fraudes e abusos (legítimo interesse).",
+        "Cumprir obrigações legais e responder a solicitações de autoridades quando exigido por lei.",
+        "Comunicações transacionais relacionadas à conta (execução de contrato). Marketing direto, quando houver, dependerá de consentimento ou opt-out conforme a lei.",
+      ],
+    },
+    {
+      title: "4. Compartilhamento",
+      paragraphs: [
+        "Não vendemos dados pessoais. Compartilhamento ocorre apenas com provedores de infraestrutura necessários à operação (hospedagem, banco de dados, e-mail transacional, busca/indexação), sob contratos ou cláusulas que exijam proteção adequada.",
+        "Dados podem ser divulgados se exigido por lei, ordem judicial ou para proteger direitos, segurança e integridade do serviço e dos usuários.",
+      ],
+    },
+    {
+      title: "5. Retenção e eliminação",
+      paragraphs: [
+        "Mantemos dados enquanto a conta estiver ativa e pelo tempo necessário para cumprir finalidades descritas, obrigações legais, resolução de disputas e backups de segurança.",
+        "Após exclusão da conta, dados pessoais serão eliminados ou anonimizados quando não houver base legal para retenção, ressalvadas cópias em backup por prazo limitado.",
+      ],
+    },
+    {
+      title: "6. Segurança",
+      paragraphs: [
+        "Adotamos medidas técnicas e organizacionais proporcionais ao risco: comunicação criptografada (HTTPS), controle de acesso por papéis, isolamento multi-tenant na API, auditorias de dependências e boas práticas de desenvolvimento.",
+        "Nenhum sistema é totalmente imune a incidentes. Em caso de violação relevante de dados pessoais, adotaremos medidas de mitigação e comunicação conforme exigido pela LGPD.",
+      ],
+    },
+    {
+      title: "7. Seus direitos (LGPD)",
+      paragraphs: [
+        "Você pode solicitar: confirmação de tratamento, acesso, correção, anonimização, portabilidade, eliminação de dados desnecessários, informação sobre compartilhamento e revogação de consentimento quando aplicável.",
+        "Pedidos serão atendidos em prazo razoável, podendo ser necessária verificação de identidade. O encarregado de dados (DPO), se designado, será informado nesta página.",
+      ],
+    },
+    {
+      title: "8. Cookies e armazenamento local",
+      paragraphs: [
+        "Utilizamos armazenamento local do navegador para token de sessão (JWT) e preferências de interface (ex.: tema claro/escuro), necessários ao funcionamento autenticado.",
+        "Não utilizamos, nesta versão, cookies de publicidade de terceiros. Ferramentas analíticas, se introduzidas futuramente, serão descritas aqui com opções de consentimento quando exigidas.",
+      ],
+    },
+    {
+      title: "9. Transferência internacional",
+      paragraphs: [
+        "Infraestrutura ou subprocessadores podem estar localizados fora do Brasil. Nesses casos, adotamos salvaguardas compatíveis com a LGPD, como cláusulas contratuais padrão ou países com nível adequado de proteção reconhecido.",
+      ],
+    },
+    {
+      title: "10. Menores de idade",
+      paragraphs: [
+        "O serviço destina-se a estabelecimentos comerciais e seus colaboradores. Não coletamos intencionalmente dados de menores de 18 anos para cadastro autônomo.",
+      ],
+    },
+    {
+      title: "11. Alterações desta política",
+      paragraphs: [
+        "Esta política pode ser atualizada. A data da última revisão será indicada no topo. Alterações relevantes poderão ser comunicadas por e-mail ou aviso na aplicação.",
+      ],
+    },
+  ],
+};
+
+export default privacy;

--- a/src/app/_lib/legal/terms/en.ts
+++ b/src/app/_lib/legal/terms/en.ts
@@ -1,0 +1,82 @@
+import type {LegalDocument} from "@/app/_lib/legal/types";
+
+const terms: LegalDocument = {
+  title: "Terms of Use",
+  lastUpdated: "June 10, 2026",
+  intro:
+    "These Terms of Use govern access to and use of uButeco, a bar and restaurant management platform offered as software as a service (SaaS). By creating an account or using the service, you agree to these terms.",
+  sections: [
+    {
+      title: "1. Service scope",
+      paragraphs: [
+        "uButeco is a multi-tenant system that helps establishments manage menus, orders, kitchen queues, staff users, and organization settings.",
+        "The service is provided as currently available (including demo or production environments) and may change, be suspended, or discontinued with reasonable notice when possible.",
+      ],
+    },
+    {
+      title: "2. Eligibility and accounts",
+      paragraphs: [
+        "You must have legal authority to bind the business you represent. You agree to provide accurate registration data and keep it up to date.",
+        "Access credentials are personal. You are responsible for activity under your account and must report unauthorized use promptly.",
+      ],
+    },
+    {
+      title: "3. Organizations and roles",
+      paragraphs: [
+        "Each establishment operates in an isolated organization. Roles (admin, kitchen, waiter, cashier, etc.) control what each user can access within that organization.",
+        "Organization administrators are responsible for team access and appropriate use of the system.",
+      ],
+    },
+    {
+      title: "4. Acceptable use",
+      paragraphs: [
+        "You may not use uButeco for unlawful purposes, to access other organizations' data, to disrupt security or availability, or to upload malicious content.",
+        "You retain ownership of operational data you enter. You grant uButeco a limited license to host, process, and display that data solely to provide the service.",
+      ],
+    },
+    {
+      title: "5. Availability and changes",
+      paragraphs: [
+        "We use reasonable efforts to keep the service available but do not guarantee uninterrupted or error-free operation. Maintenance may occur.",
+        "Features may be added, changed, or removed as the product evolves.",
+      ],
+    },
+    {
+      title: "6. Plans and billing",
+      paragraphs: [
+        "When paid plans are offered, commercial terms will be presented at purchase. Free or beta access may change with prior notice.",
+        "Non-payment or violation of these terms may result in suspension or termination.",
+      ],
+    },
+    {
+      title: "7. Intellectual property",
+      paragraphs: [
+        "Software, branding, and documentation remain the property of uButeco and its licensors. Open-source components are used under their respective licenses.",
+        "Feedback may be used to improve the product without obligation to compensate you.",
+      ],
+    },
+    {
+      title: "8. Limitation of liability",
+      paragraphs: [
+        "To the extent permitted by law, uButeco is not liable for lost profits, data loss caused by misuse or third-party failures, or operational decisions based on information shown in the app.",
+        "The service is provided \"as is.\" Maintain your own backup and verification procedures for critical operations.",
+      ],
+    },
+    {
+      title: "9. Termination",
+      paragraphs: [
+        "You may close your account using in-app features where available. We may suspend or terminate accounts that violate these terms or pose a security risk.",
+        "After termination, data may be retained as required by law or backup policy, then deleted per the Privacy Policy.",
+      ],
+    },
+    {
+      title: "10. Updates and governing law",
+      paragraphs: [
+        "These terms may be updated; the revision date appears at the top of this page. Continued use after changes constitutes acceptance.",
+        "Brazilian law applies unless otherwise required by mandatory local rules for your jurisdiction.",
+      ],
+    },
+  ],
+};
+
+export default terms;

--- a/src/app/_lib/legal/terms/pt-BR.ts
+++ b/src/app/_lib/legal/terms/pt-BR.ts
@@ -1,0 +1,82 @@
+import type {LegalDocument} from "@/app/_lib/legal/types";
+
+const terms: LegalDocument = {
+  title: "Termos de Uso",
+  lastUpdated: "10 de junho de 2026",
+  intro:
+    "Estes Termos de Uso regulam o acesso e a utilização do uButeco, plataforma de gestão para bares e restaurantes operada como software como serviço (SaaS). Ao criar uma conta ou utilizar o serviço, você concorda com estes termos.",
+  sections: [
+    {
+      title: "1. Quem somos e escopo do serviço",
+      paragraphs: [
+        "O uButeco é um sistema multi-tenant que permite a estabelecimentos gerenciar cardápio, pedidos, fila de cozinha, usuários e configurações operacionais da organização.",
+        "O serviço é oferecido na modalidade atualmente disponível (incluindo ambientes de demonstração ou produção), podendo ser alterado, suspenso ou descontinuado mediante aviso razoável quando possível.",
+      ],
+    },
+    {
+      title: "2. Elegibilidade e conta",
+      paragraphs: [
+        "Você deve ter capacidade legal para contratar em nome do estabelecimento que representa. Ao se cadastrar, declara que as informações fornecidas são verdadeiras e que manterá seus dados atualizados.",
+        "Credenciais de acesso são pessoais e intransferíveis. Você é responsável por todas as atividades realizadas na conta e deve notificar imediatamente qualquer uso não autorizado.",
+      ],
+    },
+    {
+      title: "3. Organizações e papéis de acesso",
+      paragraphs: [
+        "Cada estabelecimento opera em uma organização isolada. Papéis (administrador, cozinha, garçom, caixa, etc.) definem o que cada usuário pode ver ou alterar dentro da organização.",
+        "O administrador da organização é responsável por convites, permissões e pelo uso adequado do sistema por sua equipe.",
+      ],
+    },
+    {
+      title: "4. Uso aceitável",
+      paragraphs: [
+        "É proibido utilizar o uButeco para fins ilícitos, para tentar acessar dados de outras organizações, para interferir na segurança ou disponibilidade do serviço, ou para enviar conteúdo malicioso.",
+        "Você mantém a titularidade dos dados operacionais inseridos (pedidos, cardápio, clientes internos). Concede ao uButeco licença limitada para hospedar, processar e exibir esses dados apenas para prestar o serviço.",
+      ],
+    },
+    {
+      title: "5. Disponibilidade e suporte",
+      paragraphs: [
+        "Empregamos esforços razoáveis para manter o serviço disponível, mas não garantimos operação ininterrupta ou livre de erros. Manutenções programadas ou emergenciais podem ocorrer.",
+        "Recursos podem ser adicionados, modificados ou removidos conforme evolução do produto. Documentação e APIs publicadas podem ser atualizadas.",
+      ],
+    },
+    {
+      title: "6. Planos, preços e pagamento",
+      paragraphs: [
+        "Quando funcionalidades pagas forem oferecidas, condições comerciais específicas serão apresentadas no momento da contratação. Enquanto o serviço for disponibilizado gratuitamente ou em beta, isso poderá mudar com aviso prévio.",
+        "Inadimplência ou violação destes termos pode resultar em suspensão ou encerramento do acesso.",
+      ],
+    },
+    {
+      title: "7. Propriedade intelectual",
+      paragraphs: [
+        "O software, marca, layout e documentação do uButeco permanecem de titularidade de seus autores e licenciantes. Componentes open-source são utilizados conforme suas respectivas licenças.",
+        "Feedback ou sugestões enviados podem ser utilizados para melhorar o produto sem obrigação de compensação.",
+      ],
+    },
+    {
+      title: "8. Limitação de responsabilidade",
+      paragraphs: [
+        "Na extensão permitida pela lei aplicável, o uButeco não se responsabiliza por lucros cessantes, perda de dados causada por mau uso ou falhas de terceiros, ou decisões operacionais tomadas com base em informações exibidas no sistema.",
+        "O serviço é fornecido \"como está\". Recomendamos backups e procedimentos internos de conferência para operações críticas do estabelecimento.",
+      ],
+    },
+    {
+      title: "9. Encerramento",
+      paragraphs: [
+        "Você pode solicitar encerramento da conta conforme funcionalidades disponíveis na aplicação. Podemos suspender ou encerrar contas que violem estes termos ou representem risco à segurança.",
+        "Após encerramento, dados poderão ser retidos pelo período necessário para cumprimento legal ou backup, e depois eliminados conforme a Política de Privacidade.",
+      ],
+    },
+    {
+      title: "10. Alterações e lei aplicável",
+      paragraphs: [
+        "Estes termos podem ser atualizados. A data da última revisão constará no topo desta página. O uso continuado após alterações constitui aceite.",
+        "Aplica-se a legislação brasileira. Fica eleito o foro da comarca do domicílio do usuário pessoa jurídica ou, na ausência de domicílio comercial no Brasil, o foro da capital do Estado de São Paulo.",
+      ],
+    },
+  ],
+};
+
+export default terms;

--- a/src/app/_lib/legal/types.ts
+++ b/src/app/_lib/legal/types.ts
@@ -1,0 +1,13 @@
+export type LegalSection = {
+  title: string;
+  paragraphs: string[];
+};
+
+export type LegalDocument = {
+  title: string;
+  lastUpdated: string;
+  intro: string;
+  sections: LegalSection[];
+};
+
+export type LegalDocumentKind = "terms" | "privacy";

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,25 @@
+import type {Metadata} from "next";
 import {Roboto, Roboto_Mono} from "next/font/google";
 import "./globals.css";
 
 import {AppearanceScript} from "@/app/_components/AppearanceScript";
 import {Providers} from "@/app/providers";
+
+export const metadata: Metadata = {
+  title: {
+    default: "uButeco — Gestão para bares e restaurantes",
+    template: "%s | uButeco",
+  },
+  description:
+    "SaaS multi-tenant para bares e restaurantes: pedidos, fila da cozinha em tempo real, cardápio e configurações regionais.",
+  openGraph: {
+    title: "uButeco — Gestão para bares e restaurantes",
+    description:
+      "Pedidos, cozinha ao vivo, cardápio e equipe — uma plataforma feita para hospitality.",
+    locale: "pt_BR",
+    type: "website",
+  },
+};
 
 const robotoSans = Roboto({
   variable: "--font-roboto-sans",
@@ -20,7 +37,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="pt-BR" suppressHydrationWarning>
       <body className={`${robotoSans.variable} ${robotoMono.variable} antialiased`}>
         <AppearanceScript/>
         <Providers>{children}</Providers>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,13 +2,28 @@
 
 import dynamic from "next/dynamic";
 import {Loading} from "@/app/_components";
+import {LandingPage} from "@/app/_components/marketing/LandingPage";
 import {useAuthCapabilities} from "@/app/_hooks/useAuthCapabilities";
+import {useClientReady} from "@/app/_hooks/useClientReady";
 import {canAccessDashboard, isSuperAdmin} from "@/app/_lib/auth-roles";
+import {getAuthToken} from "@/app/_lib/auth-storage";
 import OrganizationDashboard from "@/app/dashboard/OrganizationDashboard";
 import {SuperAdminHome} from "@/app/dashboard/components/SuperAdminHome";
+import {useAppSelector} from "@/app/_store/hooks";
 
 function HomePage() {
+  const ready = useClientReady();
+  const authStatus = useAppSelector((state) => state.auth.status);
   const {user} = useAuthCapabilities();
+  const isAuthenticated = Boolean(getAuthToken()) || authStatus === "authenticated";
+
+  if (!ready) {
+    return <Loading/>;
+  }
+
+  if (!isAuthenticated) {
+    return <LandingPage/>;
+  }
 
   if (!user) {
     return <Loading/>;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import dynamic from "next/dynamic";
 import {Loading} from "@/app/_components";
 import {LandingPage} from "@/app/_components/marketing/LandingPage";
 import {useAuthCapabilities} from "@/app/_hooks/useAuthCapabilities";
@@ -11,11 +10,12 @@ import OrganizationDashboard from "@/app/dashboard/OrganizationDashboard";
 import {SuperAdminHome} from "@/app/dashboard/components/SuperAdminHome";
 import {useAppSelector} from "@/app/_store/hooks";
 
-function HomePage() {
+export default function HomePage() {
   const ready = useClientReady();
   const authStatus = useAppSelector((state) => state.auth.status);
   const {user} = useAuthCapabilities();
-  const isAuthenticated = Boolean(getAuthToken()) || authStatus === "authenticated";
+  const isAuthenticated =
+    ready && (Boolean(getAuthToken()) || authStatus === "authenticated");
 
   if (!ready) {
     return <Loading/>;
@@ -39,5 +39,3 @@ function HomePage() {
 
   return <Loading/>;
 }
-
-export default dynamic(() => Promise.resolve(HomePage), {ssr: false});

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import {LegalPageLayout} from "@/app/_components/marketing/LegalPageLayout";
+import {useOrganizationSettings} from "@/app/_hooks/useOrganizationSettings";
+import {getLegalDocument} from "@/app/_lib/legal";
+
+export default function PrivacyPage() {
+  const {locale} = useOrganizationSettings();
+  const document = getLegalDocument("privacy", locale);
+
+  return <LegalPageLayout content={document}/>;
+}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {FormEvent, useState} from "react";
+import Link from "next/link";
 import {useRouter} from "next/navigation";
 import {AuthFooterLink, AuthShell} from "@/app/_components/AuthShell";
 import {Buttons, Input} from "@/app/_components";
@@ -111,6 +112,18 @@ export default function SignUpPage() {
         <Buttons type="submit" className="w-full rounded-xl" disabled={status === "loading"}>
           {status === "loading" ? t("auth.creatingAccount") : t("auth.createAccount")}
         </Buttons>
+
+        <p className="text-center text-xs leading-relaxed text-muted">
+          {t("legal.signUpNoticePrefix")}{" "}
+          <Link href="/terms" className="font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400">
+            {t("marketing.footer.terms")}
+          </Link>{" "}
+          {t("legal.signUpNoticeAnd")}{" "}
+          <Link href="/privacy" className="font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400">
+            {t("marketing.footer.privacy")}
+          </Link>
+          .
+        </p>
       </form>
     </AuthShell>
   );

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import {LegalPageLayout} from "@/app/_components/marketing/LegalPageLayout";
+import {useOrganizationSettings} from "@/app/_hooks/useOrganizationSettings";
+import {getLegalDocument} from "@/app/_lib/legal";
+
+export default function TermsPage() {
+  const {locale} = useOrganizationSettings();
+  const document = getLegalDocument("terms", locale);
+
+  return <LegalPageLayout content={document}/>;
+}


### PR DESCRIPTION
## Summary
- Public responsive landing at `/` for logged-out visitors; authenticated users still see the dashboard
- Marketing shell routing (`isMarketingShellPath`) without sidebar for `/`, auth pages, `/terms`, and `/privacy`
- Terms of Use and Privacy Policy (pt-BR + en) with footer and signup acceptance links
- Hydration fix: remove `dynamic({ ssr: false })` from home page and defer auth decisions until `useClientReady`
- Plan 14 updated; root layout metadata + OG defaults

## Companion
- Document titles (plan 10): https://github.com/Sartori-RIA/ubuteco-react/pull/31 (separate PR, can merge independently)

## Test plan
- [ ] Logged out: `/` shows landing; CTAs go to `/signup`
- [ ] Logged in: `/` shows dashboard (no landing flash after load)
- [ ] `/terms` and `/privacy` readable without login; footer links work
- [ ] Signup page shows terms/privacy notice with working links
- [ ] No hydration warning on `/` (hard refresh)
- [ ] CTA button "Começar — é grátis" has readable contrast on blue section
- [ ] Responsive check ~375px / tablet / desktop
- [ ] `npm test -- src/app/_lib/auth-routes.test.ts`
- [ ] `NEXT_PUBLIC_API_URL=http://localhost:3000 npm run build`


Made with [Cursor](https://cursor.com)