### PR TITLE
feat(marketing): landing visual refresh + brand consistency (plan 14)

### DIFF
--- a/docs/plans/14-landing-page.md
+++ b/docs/plans/14-landing-page.md
@@ -1,9 +1,9 @@
 # Plan: Marketing landing page (frontend)
 
-**Status:** in progress  
+**Status:** completed  
 **Project:** ubuteco-react  
 **Backend:** — (optional: public stats or lead capture API later)  
-**Branch:** `feature/landing-page`  
+**Branch:** `feature/landing-page-visual`  
 **Priority:** P2
 
 ---
@@ -44,6 +44,8 @@ Copy in **pt-BR** (+ en, es, fr in i18n catalog).
 - [x] Hero kitchen-board mock (CSS, no external asset)
 - [x] Dark mode via existing tokens
 - [x] Root `metadata` + OG defaults in `layout.tsx`
+- [x] **Visual refresh (Jun 2026):** warm gradients, Unsplash showcase photos, logo mark, colored feature cards, stats row
+- [x] **Brand consistency:** shared `brand-styles` across landing, auth (`AuthShell`), legal pages, and app shell (`SidebarLayout`)
 
 ---
 
@@ -68,7 +70,7 @@ Copy in **pt-BR** (+ en, es, fr in i18n catalog).
 - [x] Anonymous visitor at `/` sees landing with CTA to `/signup`
 - [x] Authenticated user at `/` sees dashboard
 - [x] Marketing pages work without sidebar; app routes unchanged
-- [ ] Layout verified on mobile (~375px), tablet, and desktop breakpoints (manual QA)
+- [x] Layout verified on mobile (~375px), tablet, and desktop breakpoints (manual QA)
 - [x] Plan linked from [README](./README.md)
 
 ---
@@ -76,5 +78,7 @@ Copy in **pt-BR** (+ en, es, fr in i18n catalog).
 ## References
 
 - `src/app/_components/marketing/LandingPage.tsx`
+- `src/app/_components/marketing/brand-styles.tsx`
+- `src/app/_components/AuthShell.tsx`
 - `src/app/login/page.tsx`, `src/app/signup/page.tsx`
 - Plan [02-locale-and-currency](./02-locale-and-currency.md)

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -43,7 +43,7 @@ Ordered by priority. **#3 is deferred to the end** (see note above).
 | 12 | [Appearance — dark mode](./12-appearance-dark-mode.md) | completed | P2 | — |
 | 10 | [Browser document titles](./10-document-titles.md) | completed | P2 | — |
 | 9 | [Frontend performance](./09-frontend-performance.md) | in progress | P2 | — |
-| 14 | [Marketing landing page](./14-landing-page.md) | in progress | P2 | — |
+| 14 | [Marketing landing page](./14-landing-page.md) | completed | P2 | — |
 | 15 | [Product expiry alerts](./15-product-expiry-alerts.md) | not started | P2 | [15-product-expiry-alerts](../../../ubuteco_api/docs/plans/15-product-expiry-alerts.md) |
 | 3 | [Subscription plans](./03-subscription-plans.md) | not started | **Last** | [API](../../../ubuteco_api/docs/plans/03-subscription-plans.md) |
 
@@ -51,12 +51,13 @@ Ordered by priority. **#3 is deferred to the end** (see note above).
 
 | Plan | PR | Notes |
 |------|-----|-------|
+| [09 Frontend performance](./09-frontend-performance.md) | [#33](https://github.com/Sartori-RIA/ubuteco-react/pull/33) | Auth fetch dedup, orders list cache, kitchen memo |
 | [08 Settings — account deletion](./08-settings-account-deletion.md) | [#28](https://github.com/Sartori-RIA/ubuteco-react/pull/28) | Danger zone only for org admin; staff/super-admin guidance |
 | [11 Inventory UI](./11-inventory-ui.md) | [#26](https://github.com/Sartori-RIA/ubuteco-react/pull/26) | Stock display, adjust panel, `/inventory`, i18n follow-ups |
 | [02 Locale & currency](./02-locale-and-currency.md) | [#27](https://github.com/Sartori-RIA/ubuteco-react/pull/27) | `es`, `fr`, `fr-CA`, `en-CA`; CAD + LATAM pesos; Brazil/Canada/EU timezones; order status UX |
 | [10 Browser document titles](./10-document-titles.md) | [#31](https://github.com/Sartori-RIA/ubuteco-react/pull/31) | `useDocumentTitle`, `page-titles`, entity titles on detail/edit routes |
 
-**In progress:** [01 Multi-tenant](./01-multi-tenant.md) (Phases 3–4), [09 Frontend performance](./09-frontend-performance.md), [14 Marketing landing page](./14-landing-page.md).
+**In progress:** [01 Multi-tenant](./01-multi-tenant.md) (Phases 3–4), [09 Frontend performance](./09-frontend-performance.md).
 
 **Next up:** [15 Product expiry alerts](./15-product-expiry-alerts.md). **Last:** [03 Subscription plans](./03-subscription-plans.md).
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -51,6 +51,7 @@ Ordered by priority. **#3 is deferred to the end** (see note above).
 
 | Plan | PR | Notes |
 |------|-----|-------|
+| [14 Marketing landing page](./14-landing-page.md) | [#34](https://github.com/Sartori-RIA/ubuteco-react/pull/34) | Visual refresh, photos, auth/app shell brand consistency |
 | [09 Frontend performance](./09-frontend-performance.md) | [#33](https://github.com/Sartori-RIA/ubuteco-react/pull/33) | Auth fetch dedup, orders list cache, kitchen memo |
 | [08 Settings — account deletion](./08-settings-account-deletion.md) | [#28](https://github.com/Sartori-RIA/ubuteco-react/pull/28) | Danger zone only for org admin; staff/super-admin guidance |
 | [11 Inventory UI](./11-inventory-ui.md) | [#26](https://github.com/Sartori-RIA/ubuteco-react/pull/26) | Stock display, adjust panel, `/inventory`, i18n follow-ups |

--- a/next.config.ts
+++ b/next.config.ts
@@ -28,6 +28,11 @@ const nextConfig: NextConfig = {
         port: "3000",
         pathname: "/rails/active_storage/**",
       },
+      {
+        protocol: "https",
+        hostname: "images.unsplash.com",
+        pathname: "/**",
+      },
     ],
   },
 };

--- a/public/marketing/logo-mark.svg
+++ b/public/marketing/logo-mark.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" fill="none" role="img" aria-hidden="true">
+  <rect width="40" height="40" rx="12" fill="url(#ub-gradient)"/>
+  <path d="M12 14h16v3c0 5.5-3.5 9.5-8 10.5-4.5-1-8-5-8-10.5v-3z" fill="white" fill-opacity="0.95"/>
+  <path d="M14 11h12v2H14v-2z" fill="white" fill-opacity="0.8"/>
+  <ellipse cx="20" cy="26" rx="5" ry="1.5" fill="#F59E0B" fill-opacity="0.9"/>
+  <defs>
+    <linearGradient id="ub-gradient" x1="8" y1="4" x2="32" y2="36" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#2563EB"/>
+      <stop offset="1" stop-color="#D97706"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/app/_components/AuthShell.tsx
+++ b/src/app/_components/AuthShell.tsx
@@ -1,5 +1,11 @@
+"use client";
+
+import Image from "next/image";
 import Link from "next/link";
 import {ReactNode} from "react";
+import {AMBIENT_BLOBS, AMBIENT_PAGE} from "@/app/_components/marketing/brand-styles";
+import {MARKETING_IMAGES} from "@/app/_components/marketing/marketing-images";
+import {useTranslations} from "@/app/_hooks/useTranslations";
 
 type Props = {
   title: string;
@@ -9,21 +15,63 @@ type Props = {
 };
 
 export function AuthShell({title, subtitle, children, footer}: Props) {
+  const t = useTranslations();
+
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background p-6">
-      <div className="w-full max-w-md space-y-6 rounded-2xl border border-border bg-surface p-8 shadow-lg">
-        <div>
-          <h1 className="text-2xl font-bold text-foreground">{title}</h1>
-          <p className="mt-1 text-sm text-muted">{subtitle}</p>
+    <div className={`relative flex min-h-screen flex-col overflow-hidden ${AMBIENT_PAGE} lg:flex-row`}>
+      {AMBIENT_BLOBS}
+
+      <div className="relative hidden min-h-screen w-[42%] flex-col justify-between border-r border-amber-200/40 p-10 xl:w-[44%] xl:p-12 dark:border-amber-900/30 lg:flex">
+        <Link href="/" className="flex items-center gap-2.5 text-lg font-bold tracking-tight text-foreground">
+          <Image src="/marketing/logo-mark.svg" alt="" width={40} height={40} className="h-10 w-10 shrink-0"/>
+          <span>{t("common.appName")}</span>
+        </Link>
+
+        <div className="space-y-4">
+          <span className="inline-flex items-center rounded-full border border-amber-300/70 bg-amber-100/80 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-900 dark:border-amber-700/50 dark:bg-amber-950/50 dark:text-amber-200">
+            {t("marketing.hero.badge")}
+          </span>
+          <p className="max-w-md text-2xl font-bold leading-snug text-foreground xl:text-3xl">
+            {t("marketing.problem.title")}
+          </p>
+          <p className="max-w-md text-sm leading-relaxed text-muted">{t("marketing.hero.subtitle")}</p>
         </div>
-        {children}
-        {footer}
+
+        <div className="relative overflow-hidden rounded-2xl shadow-2xl ring-4 ring-white/50 dark:ring-amber-900/30">
+          <Image
+            src={MARKETING_IMAGES.showcaseDining}
+            alt={t("marketing.showcase.dining")}
+            width={640}
+            height={480}
+            className="aspect-[4/3] w-full object-cover"
+            sizes="44vw"
+            priority
+          />
+          <div className="absolute inset-0 bg-gradient-to-t from-amber-950/60 via-transparent to-blue-900/10"/>
+        </div>
+      </div>
+
+      <div className="relative flex flex-1 items-center justify-center p-6 sm:p-8">
+        <div className="w-full max-w-md space-y-6 rounded-2xl border border-white/60 bg-white/90 p-8 shadow-xl backdrop-blur-sm dark:border-border dark:bg-surface/95">
+          <Link href="/" className="flex items-center gap-2 lg:hidden">
+            <Image src="/marketing/logo-mark.svg" alt="" width={32} height={32} className="h-8 w-8"/>
+            <span className="font-bold text-foreground">{t("common.appName")}</span>
+          </Link>
+
+          <div>
+            <h1 className="text-2xl font-bold text-foreground">{title}</h1>
+            <p className="mt-1 text-sm text-muted">{subtitle}</p>
+          </div>
+
+          {children}
+          {footer}
+        </div>
       </div>
     </div>
   );
 }
 
-export function AuthFooterLink({href, children}: { href: string; children: ReactNode }) {
+export function AuthFooterLink({href, children}: {href: string; children: ReactNode}) {
   return (
     <p className="text-center text-sm text-muted">
       <Link href={href} className="font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300">

--- a/src/app/_components/SidebarLayout.tsx
+++ b/src/app/_components/SidebarLayout.tsx
@@ -1,9 +1,11 @@
 "use client"
 
+import Image from "next/image";
 import React, {ReactNode, useState} from "react";
 import {AnimatePresence, motion} from "framer-motion";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faBars, faRightFromBracket, faUser} from "@fortawesome/free-solid-svg-icons";
+import {AMBIENT_APP} from "@/app/_components/marketing/brand-styles";
 import {isMarketingShellPath} from "@/app/_lib/auth-routes";
 import {getAuthToken} from "@/app/_lib/auth-storage";
 import {getVisibleNavGroups} from "@/app/_lib/nav-config";
@@ -49,7 +51,7 @@ export default function SidebarLayout({children}: { children: ReactNode }) {
       : "text-gray-700 hover:bg-gray-200 dark:text-gray-200 dark:hover:bg-gray-800";
 
   return (
-    <div className="flex h-screen bg-background">
+    <div className={`flex h-screen ${AMBIENT_APP}`}>
       <AnimatePresence>
         {isOpen && (
           <motion.aside
@@ -57,13 +59,18 @@ export default function SidebarLayout({children}: { children: ReactNode }) {
             animate={{width: 260, opacity: 1}}
             exit={{width: 0, opacity: 0}}
             transition={{duration: 0.25}}
-            className="flex h-full min-h-0 flex-col overflow-hidden border-r border-border bg-surface shadow-xl"
+            className="flex h-full min-h-0 flex-col overflow-hidden border-r border-amber-200/40 bg-surface shadow-xl dark:border-amber-900/30"
           >
-            <div className="shrink-0 border-b border-border p-4">
-              <h1 className="text-lg font-bold tracking-tight text-foreground">{t("common.appName")}</h1>
-              <p className="truncate text-sm text-muted">
-                {user?.name ?? user?.email ?? t("common.adminPanel")}
-              </p>
+            <div className="shrink-0 border-b border-amber-200/40 bg-gradient-to-r from-amber-50/90 via-surface to-blue-50/70 p-4 dark:border-amber-900/30 dark:from-amber-950/40 dark:via-surface dark:to-blue-950/30">
+              <div className="flex items-center gap-2.5">
+                <Image src="/marketing/logo-mark.svg" alt="" width={32} height={32} className="h-8 w-8 shrink-0"/>
+                <div className="min-w-0">
+                  <h1 className="truncate text-lg font-bold tracking-tight text-foreground">{t("common.appName")}</h1>
+                  <p className="truncate text-sm text-muted">
+                    {user?.name ?? user?.email ?? t("common.adminPanel")}
+                  </p>
+                </div>
+              </div>
               {isSuperAdmin && (
                 <p className="mt-1 truncate text-xs font-medium text-amber-700 dark:text-amber-400">
                   {t("nav.platformReadOnly")}
@@ -110,7 +117,7 @@ export default function SidebarLayout({children}: { children: ReactNode }) {
       </AnimatePresence>
 
       <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-        <header className="flex shrink-0 items-center justify-between border-b border-border bg-surface p-4">
+        <header className="flex shrink-0 items-center justify-between border-b border-amber-200/40 bg-surface/90 p-4 backdrop-blur-sm dark:border-amber-900/30">
           <div className="flex items-center gap-3">
             <Buttons
               variant="outline"
@@ -143,8 +150,16 @@ export default function SidebarLayout({children}: { children: ReactNode }) {
           </Link>
         </header>
 
-        <main className="min-h-0 flex-1 overflow-auto p-6">
-          {children}
+        <main className="relative min-h-0 flex-1 overflow-auto p-6">
+          <div
+            aria-hidden
+            className="pointer-events-none absolute right-0 top-0 h-56 w-56 rounded-full bg-amber-300/10 blur-3xl dark:bg-amber-600/5"
+          />
+          <div
+            aria-hidden
+            className="pointer-events-none absolute bottom-0 left-0 h-48 w-48 rounded-full bg-blue-400/10 blur-3xl dark:bg-blue-600/5"
+          />
+          <div className="relative">{children}</div>
         </main>
       </div>
     </div>

--- a/src/app/_components/marketing/KitchenQueueMock.tsx
+++ b/src/app/_components/marketing/KitchenQueueMock.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import {useTranslations} from "@/app/_hooks/useTranslations";
+
+const COLUMN_KEYS = ["awaiting", "cooking", "ready", "done"] as const;
+
+export function KitchenQueueMock() {
+  const t = useTranslations();
+
+  return (
+    <div className="rounded-2xl border border-white/60 bg-white/95 p-5 shadow-2xl ring-1 ring-amber-200/60 backdrop-blur-sm dark:border-white/10 dark:bg-surface/95 dark:ring-amber-900/40">
+      <div className="mb-4 flex items-center justify-between text-xs font-medium text-muted">
+        <span>{t("nav.kitchen")}</span>
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-100 px-2 py-0.5 text-emerald-700 dark:bg-emerald-950/60 dark:text-emerald-300">
+          <span className="h-2 w-2 animate-pulse rounded-full bg-emerald-500"/>
+          {t("marketing.hero.mock.live")}
+        </span>
+      </div>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {COLUMN_KEYS.map((key, index) => (
+          <div
+            key={key}
+            className="rounded-xl border border-border/80 bg-gradient-to-b from-surface-muted to-amber-50/50 p-3 dark:to-amber-950/20"
+          >
+            <p className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-muted">
+              {t(`kitchen.columns.${key}`)}
+            </p>
+            {index === 0 ? (
+              <div className="rounded-lg border border-blue-200 bg-gradient-to-br from-blue-50 to-blue-100/80 p-2 text-xs dark:border-blue-800 dark:from-blue-950/60 dark:to-blue-900/40">
+                <p className="font-semibold text-foreground">{t("marketing.hero.mock.ticketName")}</p>
+                <p className="text-muted">{t("marketing.hero.mock.ticketMeta")}</p>
+              </div>
+            ) : index === 1 ? (
+              <div className="rounded-lg border border-orange-200 bg-gradient-to-br from-orange-50 to-amber-100/80 p-2 text-xs dark:border-orange-800 dark:from-orange-950/40 dark:to-amber-950/30">
+                <p className="font-semibold text-foreground">{t("marketing.hero.mock.ticketCooking")}</p>
+                <p className="text-muted">{t("marketing.hero.mock.ticketCookingMeta")}</p>
+              </div>
+            ) : (
+              <p className="py-4 text-center text-[10px] text-muted">—</p>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/_components/marketing/LandingPage.tsx
+++ b/src/app/_components/marketing/LandingPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {useEffect} from "react";
+import Image from "next/image";
 import Link from "next/link";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {
@@ -10,38 +11,68 @@ import {
   faGlobe,
 } from "@fortawesome/free-solid-svg-icons";
 import {Buttons} from "@/app/_components";
+import {KitchenQueueMock} from "@/app/_components/marketing/KitchenQueueMock";
+import {MARKETING_IMAGES} from "@/app/_components/marketing/marketing-images";
 import {MarketingFooter} from "@/app/_components/marketing/MarketingFooter";
 import {MarketingHeader} from "@/app/_components/marketing/MarketingHeader";
 import {useTranslations} from "@/app/_hooks/useTranslations";
 import type {TranslationKey} from "@/app/_lib/i18n";
 
-const FEATURES: Array<{id: string; icon: typeof faBellConcierge; titleKey: TranslationKey; bodyKey: TranslationKey}> =
-  [
-    {
-      id: "operations",
-      icon: faBellConcierge,
-      titleKey: "marketing.features.operations.title",
-      bodyKey: "marketing.features.operations.body",
-    },
-    {
-      id: "catalog",
-      icon: faBookOpen,
-      titleKey: "marketing.features.catalog.title",
-      bodyKey: "marketing.features.catalog.body",
-    },
-    {
-      id: "kitchen",
-      icon: faFireBurner,
-      titleKey: "marketing.features.kitchen.title",
-      bodyKey: "marketing.features.kitchen.body",
-    },
-    {
-      id: "settings",
-      icon: faGlobe,
-      titleKey: "marketing.features.settings.title",
-      bodyKey: "marketing.features.settings.body",
-    },
-  ];
+import {BRAND_CTA} from "@/app/_components/marketing/brand-styles";
+
+const FEATURES: Array<{
+  id: string;
+  icon: typeof faBellConcierge;
+  titleKey: TranslationKey;
+  bodyKey: TranslationKey;
+  accent: string;
+  cardTint: string;
+}> = [
+  {
+    id: "operations",
+    icon: faBellConcierge,
+    titleKey: "marketing.features.operations.title",
+    bodyKey: "marketing.features.operations.body",
+    accent: "from-blue-600 to-blue-700 shadow-blue-600/30",
+    cardTint: "from-blue-50/80 to-surface dark:from-blue-950/30 dark:to-surface",
+  },
+  {
+    id: "catalog",
+    icon: faBookOpen,
+    titleKey: "marketing.features.catalog.title",
+    bodyKey: "marketing.features.catalog.body",
+    accent: "from-amber-500 to-orange-600 shadow-amber-500/30",
+    cardTint: "from-amber-50/80 to-surface dark:from-amber-950/25 dark:to-surface",
+  },
+  {
+    id: "kitchen",
+    icon: faFireBurner,
+    titleKey: "marketing.features.kitchen.title",
+    bodyKey: "marketing.features.kitchen.body",
+    accent: "from-orange-500 to-red-600 shadow-orange-500/30",
+    cardTint: "from-orange-50/80 to-surface dark:from-orange-950/25 dark:to-surface",
+  },
+  {
+    id: "settings",
+    icon: faGlobe,
+    titleKey: "marketing.features.settings.title",
+    bodyKey: "marketing.features.settings.body",
+    accent: "from-emerald-500 to-teal-600 shadow-emerald-500/30",
+    cardTint: "from-emerald-50/80 to-surface dark:from-emerald-950/25 dark:to-surface",
+  },
+];
+
+const SHOWCASE = [
+  {src: MARKETING_IMAGES.showcaseDining, altKey: "marketing.showcase.dining" as TranslationKey},
+  {src: MARKETING_IMAGES.showcaseKitchen, altKey: "marketing.showcase.kitchen" as TranslationKey},
+  {src: MARKETING_IMAGES.showcaseBar, altKey: "marketing.showcase.bar" as TranslationKey},
+];
+
+const PROOF_STATS = [
+  {valueKey: "marketing.proof.stats.realtime.value" as TranslationKey, labelKey: "marketing.proof.stats.realtime.label" as TranslationKey, color: "text-blue-600 dark:text-blue-400"},
+  {valueKey: "marketing.proof.stats.multitenant.value" as TranslationKey, labelKey: "marketing.proof.stats.multitenant.label" as TranslationKey, color: "text-amber-600 dark:text-amber-400"},
+  {valueKey: "marketing.proof.stats.opensource.value" as TranslationKey, labelKey: "marketing.proof.stats.opensource.label" as TranslationKey, color: "text-emerald-600 dark:text-emerald-400"},
+];
 
 export function LandingPage() {
   const t = useTranslations();
@@ -55,96 +86,154 @@ export function LandingPage() {
       <MarketingHeader/>
 
       <main className="flex-1">
-        <section className="mx-auto max-w-6xl px-4 py-16 sm:px-6 sm:py-24 lg:py-28">
-          <div className="grid items-center gap-12 lg:grid-cols-2 lg:gap-16">
-            <div className="space-y-6">
-              <h1 className="text-4xl font-bold tracking-tight sm:text-5xl lg:text-[2.75rem] lg:leading-tight">
-                {t("marketing.hero.title")}
-              </h1>
-              <p className="max-w-xl text-lg text-muted">{t("marketing.hero.subtitle")}</p>
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-                <Link href="/signup">
-                  <Buttons size="lg" className="w-full rounded-xl sm:w-auto">
-                    {t("marketing.hero.ctaPrimary")}
-                  </Buttons>
-                </Link>
-                <a
-                  href="#features"
-                  className="inline-flex h-11 items-center justify-center rounded-xl border border-border bg-surface px-6 text-sm font-medium hover:bg-surface-muted"
-                >
-                  {t("marketing.hero.ctaSecondary")}
-                </a>
-              </div>
-            </div>
+        <section className="relative overflow-hidden border-b border-amber-200/50 bg-gradient-to-br from-amber-100 via-orange-50 to-blue-100 dark:border-amber-900/40 dark:from-amber-950/40 dark:via-background dark:to-blue-950/50">
+          <div
+            aria-hidden
+            className="pointer-events-none absolute -right-24 -top-24 h-80 w-80 rounded-full bg-amber-400/25 blur-3xl dark:bg-amber-600/10"
+          />
+          <div
+            aria-hidden
+            className="pointer-events-none absolute -left-16 bottom-0 h-72 w-72 rounded-full bg-blue-500/20 blur-3xl dark:bg-blue-600/10"
+          />
+          <div
+            aria-hidden
+            className="pointer-events-none absolute right-1/3 top-1/2 h-48 w-48 rounded-full bg-orange-400/15 blur-2xl"
+          />
 
-            <div className="relative mx-auto w-full max-w-lg lg:max-w-none">
-              <div className="rounded-2xl border border-border bg-surface p-6 shadow-xl">
-                <div className="mb-4 flex items-center justify-between text-xs font-medium text-muted">
-                  <span>{t("nav.kitchen")}</span>
-                  <span className="inline-flex items-center gap-1.5 text-emerald-600 dark:text-emerald-400">
-                    <span className="h-2 w-2 rounded-full bg-emerald-500"/>
-                    Live
-                  </span>
-                </div>
-                <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-                  {["Awaiting", "Cooking", "Ready", "Done"].map((col, index) => (
-                    <div key={col} className="rounded-xl border border-border bg-surface-muted p-3">
-                      <p className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-muted">{col}</p>
-                      {index === 0 ? (
-                        <div className="rounded-lg border border-blue-200 bg-blue-50 p-2 text-xs dark:border-blue-800 dark:bg-blue-950/40">
-                          <p className="font-semibold">House Burger</p>
-                          <p className="text-muted">Table 4 · ×2</p>
-                        </div>
-                      ) : (
-                        <p className="py-4 text-center text-[10px] text-muted">—</p>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <section className="border-y border-border bg-surface-muted">
-          <div className="mx-auto max-w-3xl px-4 py-14 text-center sm:px-6 sm:py-16">
-            <h2 className="text-2xl font-bold sm:text-3xl">{t("marketing.problem.title")}</h2>
-            <p className="mt-4 text-base leading-relaxed text-muted sm:text-lg">{t("marketing.problem.body")}</p>
-          </div>
-        </section>
-
-        <section id="features" className="mx-auto max-w-6xl px-4 py-16 sm:px-6 sm:py-20">
-          <h2 className="text-center text-2xl font-bold sm:text-3xl">{t("marketing.features.title")}</h2>
-          <div className="mt-10 grid gap-6 sm:grid-cols-2 lg:gap-8">
-            {FEATURES.map(({id, icon, titleKey, bodyKey}) => (
-              <article
-                key={id}
-                className="rounded-2xl border border-border bg-surface p-6 shadow-sm transition hover:border-blue-300 dark:hover:border-blue-700"
-              >
-                <span className="inline-flex h-11 w-11 items-center justify-center rounded-xl bg-blue-600 text-white">
-                  <FontAwesomeIcon icon={icon} className="h-5 w-5"/>
+          <div className="relative mx-auto max-w-6xl px-4 py-16 pb-28 sm:px-6 sm:py-24 sm:pb-32 lg:py-28 lg:pb-36">
+            <div className="grid items-center gap-12 lg:grid-cols-2 lg:gap-16">
+              <div className="space-y-6">
+                <span className="inline-flex items-center rounded-full border border-amber-300/70 bg-amber-100/80 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-900 dark:border-amber-700/50 dark:bg-amber-950/50 dark:text-amber-200">
+                  {t("marketing.hero.badge")}
                 </span>
-                <h3 className="mt-4 text-lg font-semibold">{t(titleKey)}</h3>
-                <p className="mt-2 text-sm leading-relaxed text-muted">{t(bodyKey)}</p>
-              </article>
-            ))}
+                <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-[2.75rem] lg:leading-tight">
+                  {t("marketing.hero.title")}
+                </h1>
+                <p className="max-w-xl text-lg text-muted">{t("marketing.hero.subtitle")}</p>
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                  <Link href="/signup">
+                    <Buttons size="lg" className={`w-full rounded-xl sm:w-auto ${BRAND_CTA}`}>
+                      {t("marketing.hero.ctaPrimary")}
+                    </Buttons>
+                  </Link>
+                  <a
+                    href="#features"
+                    className="inline-flex h-11 items-center justify-center rounded-xl border border-amber-300/60 bg-white/70 px-6 text-sm font-medium text-foreground shadow-sm backdrop-blur hover:bg-white dark:border-amber-800/50 dark:bg-surface/70 dark:hover:bg-surface"
+                  >
+                    {t("marketing.hero.ctaSecondary")}
+                  </a>
+                </div>
+              </div>
+
+              <div className="relative mx-auto w-full max-w-lg lg:max-w-none">
+                <div className="relative overflow-hidden rounded-2xl shadow-2xl ring-4 ring-white/60 dark:ring-amber-900/30">
+                  <Image
+                    src={MARKETING_IMAGES.heroRestaurant}
+                    alt={t("marketing.hero.imageAlt")}
+                    width={900}
+                    height={675}
+                    priority
+                    className="aspect-[4/3] w-full object-cover"
+                    sizes="(max-width: 1024px) 100vw, 50vw"
+                  />
+                  <div className="absolute inset-0 bg-gradient-to-t from-amber-950/50 via-transparent to-blue-900/10 dark:from-black/60"/>
+                </div>
+                <div className="absolute -bottom-6 -left-4 right-4 sm:-left-8 sm:right-8 lg:-bottom-8">
+                  <KitchenQueueMock/>
+                </div>
+              </div>
+            </div>
           </div>
         </section>
 
-        <section className="border-t border-border bg-surface-muted">
-          <div className="mx-auto max-w-3xl px-4 py-14 text-center sm:px-6">
-            <h2 className="text-xl font-semibold sm:text-2xl">{t("marketing.proof.title")}</h2>
-            <p className="mt-3 text-muted">{t("marketing.proof.body")}</p>
+        <section className="border-b border-border bg-gradient-to-b from-amber-50/60 to-surface-muted dark:from-amber-950/20 dark:to-surface-muted">
+          <div className="mx-auto max-w-6xl px-4 py-14 sm:px-6 sm:py-16">
+            <div className="mx-auto max-w-3xl text-center">
+              <h2 className="text-2xl font-bold sm:text-3xl">{t("marketing.problem.title")}</h2>
+              <p className="mt-4 text-base leading-relaxed text-muted sm:text-lg">{t("marketing.problem.body")}</p>
+            </div>
+            <div className="mt-10 grid gap-4 sm:grid-cols-3">
+              {SHOWCASE.map(({src, altKey}) => (
+                <div
+                  key={altKey}
+                  className="group relative overflow-hidden rounded-2xl shadow-lg ring-1 ring-amber-200/50 transition hover:-translate-y-1 hover:shadow-xl dark:ring-amber-900/40"
+                >
+                  <Image
+                    src={src}
+                    alt={t(altKey)}
+                    width={640}
+                    height={480}
+                    className="aspect-[4/3] w-full object-cover transition duration-500 group-hover:scale-105"
+                    sizes="(max-width: 640px) 100vw, 33vw"
+                  />
+                  <div className="absolute inset-0 bg-gradient-to-t from-amber-950/70 via-amber-950/10 to-transparent"/>
+                  <p className="absolute bottom-3 left-3 right-3 text-sm font-medium text-white">{t(altKey)}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section
+          id="features"
+          className="bg-gradient-to-b from-background via-blue-50/30 to-background dark:via-blue-950/15"
+        >
+          <div className="mx-auto max-w-6xl px-4 py-16 sm:px-6 sm:py-20">
+            <h2 className="text-center text-2xl font-bold sm:text-3xl">{t("marketing.features.title")}</h2>
+            <div className="mt-10 grid gap-6 sm:grid-cols-2 lg:gap-8">
+              {FEATURES.map(({id, icon, titleKey, bodyKey, accent, cardTint}) => (
+                <article
+                  key={id}
+                  className={`rounded-2xl border border-border/80 bg-gradient-to-br ${cardTint} p-6 shadow-md transition hover:-translate-y-0.5 hover:shadow-lg`}
+                >
+                  <span
+                    className={`inline-flex h-11 w-11 items-center justify-center rounded-xl bg-gradient-to-br ${accent} text-white shadow-lg`}
+                  >
+                    <FontAwesomeIcon icon={icon} className="h-5 w-5"/>
+                  </span>
+                  <h3 className="mt-4 text-lg font-semibold">{t(titleKey)}</h3>
+                  <p className="mt-2 text-sm leading-relaxed text-muted">{t(bodyKey)}</p>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="border-y border-border bg-gradient-to-r from-amber-100/70 via-orange-50 to-blue-100/70 dark:from-amber-950/30 dark:via-surface-muted dark:to-blue-950/30">
+          <div className="mx-auto max-w-6xl px-4 py-14 sm:px-6">
+            <div className="mx-auto max-w-3xl text-center">
+              <h2 className="text-xl font-semibold sm:text-2xl">{t("marketing.proof.title")}</h2>
+              <p className="mt-3 text-muted">{t("marketing.proof.body")}</p>
+            </div>
+            <div className="mt-10 grid gap-4 sm:grid-cols-3">
+              {PROOF_STATS.map(({valueKey, labelKey, color}) => (
+                <div
+                  key={valueKey}
+                  className="rounded-2xl border border-white/60 bg-white/80 px-5 py-6 text-center shadow-sm backdrop-blur dark:border-border dark:bg-surface/80"
+                >
+                  <p className={`text-2xl font-bold ${color}`}>{t(valueKey)}</p>
+                  <p className="mt-2 text-sm text-muted">{t(labelKey)}</p>
+                </div>
+              ))}
+            </div>
           </div>
         </section>
 
         <section className="mx-auto max-w-6xl px-4 py-16 sm:px-6 sm:py-20">
-          <div className="rounded-2xl bg-blue-600 px-6 py-12 text-center text-white sm:px-10 sm:py-14">
-            <h2 className="text-2xl font-bold sm:text-3xl">{t("marketing.cta.title")}</h2>
-            <p className="mx-auto mt-3 max-w-xl text-blue-100">{t("marketing.cta.subtitle")}</p>
+          <div className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-blue-600 via-blue-700 to-amber-600 px-6 py-12 text-center text-white shadow-xl shadow-blue-900/20 sm:px-10 sm:py-14">
+            <div
+              aria-hidden
+              className="pointer-events-none absolute -right-10 -top-10 h-40 w-40 rounded-full bg-white/10 blur-2xl"
+            />
+            <div
+              aria-hidden
+              className="pointer-events-none absolute -bottom-8 -left-8 h-32 w-32 rounded-full bg-amber-400/20 blur-2xl"
+            />
+            <h2 className="relative text-2xl font-bold sm:text-3xl">{t("marketing.cta.title")}</h2>
+            <p className="relative mx-auto mt-3 max-w-xl text-blue-100">{t("marketing.cta.subtitle")}</p>
             <Link
               href="/signup"
-              className="mt-8 inline-flex h-12 items-center justify-center rounded-xl bg-white px-6 text-base font-semibold text-blue-700 shadow-sm transition hover:bg-blue-50"
+              className="relative mt-8 inline-flex h-12 items-center justify-center rounded-xl bg-white px-6 text-base font-semibold text-blue-700 shadow-lg transition hover:bg-amber-50 hover:text-blue-800"
             >
               {t("marketing.cta.button")}
             </Link>

--- a/src/app/_components/marketing/LegalPageLayout.tsx
+++ b/src/app/_components/marketing/LegalPageLayout.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import {AMBIENT_PAGE} from "@/app/_components/marketing/brand-styles";
 import {MarketingFooter} from "@/app/_components/marketing/MarketingFooter";
 import {MarketingHeader} from "@/app/_components/marketing/MarketingHeader";
 import {useDocumentTitle} from "@/app/_hooks/useDocumentTitle";
@@ -16,7 +17,7 @@ export function LegalPageLayout({content}: Props) {
   useDocumentTitle(content.title);
 
   return (
-    <div className="flex min-h-screen flex-col bg-background text-foreground">
+    <div className={`flex min-h-screen flex-col text-foreground ${AMBIENT_PAGE}`}>
       <MarketingHeader/>
 
       <main className="flex-1">

--- a/src/app/_components/marketing/MarketingHeader.tsx
+++ b/src/app/_components/marketing/MarketingHeader.tsx
@@ -1,27 +1,30 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import {Buttons} from "@/app/_components";
+import {BRAND_CTA} from "@/app/_components/marketing/brand-styles";
 import {useTranslations} from "@/app/_hooks/useTranslations";
 
 export function MarketingHeader() {
   const t = useTranslations();
 
   return (
-    <header className="sticky top-0 z-50 border-b border-border bg-surface/95 backdrop-blur supports-[backdrop-filter]:bg-surface/80">
+    <header className="sticky top-0 z-50 border-b border-amber-200/50 bg-white/90 backdrop-blur-md dark:border-amber-900/30 dark:bg-surface/90">
       <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4 sm:px-6">
-        <Link href="/" className="text-lg font-bold tracking-tight text-foreground">
-          {t("common.appName")}
+        <Link href="/" className="flex items-center gap-2.5 text-lg font-bold tracking-tight text-foreground">
+          <Image src="/marketing/logo-mark.svg" alt="" width={36} height={36} className="h-9 w-9 shrink-0"/>
+          <span>{t("common.appName")}</span>
         </Link>
         <nav className="flex items-center gap-2 sm:gap-3">
           <Link
             href="/login"
-            className="rounded-xl px-3 py-2 text-sm font-medium text-foreground hover:bg-surface-muted"
+            className="rounded-xl px-3 py-2 text-sm font-medium text-foreground hover:bg-amber-100/80 dark:hover:bg-surface-muted"
           >
             {t("marketing.header.signIn")}
           </Link>
           <Link href="/signup">
-            <Buttons size="sm" className="rounded-xl">
+            <Buttons size="sm" className={`rounded-xl ${BRAND_CTA}`}>
               {t("marketing.header.startFree")}
             </Buttons>
           </Link>

--- a/src/app/_components/marketing/brand-styles.tsx
+++ b/src/app/_components/marketing/brand-styles.tsx
@@ -1,0 +1,22 @@
+/** Shared brand accents — landing, auth, and app shell. */
+export const BRAND_CTA =
+  "!border-0 !bg-blue-600 !text-white shadow-md shadow-blue-600/20 hover:!bg-blue-700 focus:!ring-blue-600 dark:!bg-blue-500 dark:hover:!bg-blue-400";
+
+export const AMBIENT_PAGE =
+  "bg-gradient-to-br from-amber-100 via-orange-50 to-blue-100 dark:from-amber-950/40 dark:via-background dark:to-blue-950/50";
+
+export const AMBIENT_APP =
+  "bg-gradient-to-br from-background via-amber-50/25 to-blue-50/20 dark:via-amber-950/10 dark:to-blue-950/15";
+
+export const AMBIENT_BLOBS = (
+  <>
+    <div
+      aria-hidden
+      className="pointer-events-none absolute -right-24 -top-24 h-80 w-80 rounded-full bg-amber-400/20 blur-3xl dark:bg-amber-600/10"
+    />
+    <div
+      aria-hidden
+      className="pointer-events-none absolute -left-16 bottom-0 h-72 w-72 rounded-full bg-blue-500/15 blur-3xl dark:bg-blue-600/10"
+    />
+  </>
+);

--- a/src/app/_components/marketing/marketing-images.ts
+++ b/src/app/_components/marketing/marketing-images.ts
@@ -1,0 +1,11 @@
+/** Unsplash photos — hospitality ambiance (free to use under Unsplash License). */
+export const MARKETING_IMAGES = {
+  heroRestaurant:
+    "https://images.unsplash.com/photo-1517248135467-4c7edcad34c4?auto=format&fit=crop&w=900&q=80",
+  showcaseKitchen:
+    "https://images.unsplash.com/photo-1556910103-1c02745aae4d?auto=format&fit=crop&w=640&q=80",
+  showcaseBar:
+    "https://images.unsplash.com/photo-1544148103-0773bf10d330?auto=format&fit=crop&w=640&q=80",
+  showcaseDining:
+    "https://images.unsplash.com/photo-1555396273-367ea4eb4db5?auto=format&fit=crop&w=640&q=80",
+} as const;

--- a/src/app/_lib/i18n/messages/en.ts
+++ b/src/app/_lib/i18n/messages/en.ts
@@ -554,8 +554,22 @@ const en: MessageCatalog = {
       title: "Run your bar or restaurant without spreadsheet chaos",
       subtitle:
         "Orders, kitchen queue, menu catalog, and staff roles — one platform built for multi-location hospitality teams.",
+      badge: "Built for bars & restaurants",
+      imageAlt: "Warm restaurant interior with dining tables and ambient lighting",
       ctaPrimary: "Create free account",
       ctaSecondary: "See how it works",
+      mock: {
+        live: "Live",
+        ticketName: "House burger",
+        ticketMeta: "Table 4 · ×2",
+        ticketCooking: "Risotto",
+        ticketCookingMeta: "Table 7 · ×1",
+      },
+    },
+    showcase: {
+      dining: "Dining room in motion",
+      kitchen: "Kitchen at service pace",
+      bar: "Bar and beverage menu",
     },
     problem: {
       title: "Floor, kitchen, and back office on the same page",
@@ -584,6 +598,11 @@ const en: MessageCatalog = {
     proof: {
       title: "Built for bars & restaurants",
       body: "Open-source stack, multi-tenant by design, and shaped by real service workflows — not generic retail software.",
+      stats: {
+        realtime: {value: "Real-time", label: "Kitchen queue over WebSocket"},
+        multitenant: {value: "Multi-tenant", label: "One account, many locations"},
+        opensource: {value: "Open source", label: "Rails + Next.js, open stack"},
+      },
     },
     cta: {
       title: "Ready to simplify service?",

--- a/src/app/_lib/i18n/messages/es.ts
+++ b/src/app/_lib/i18n/messages/es.ts
@@ -553,8 +553,22 @@ const es: MessageCatalog = {
       title: "Gestiona tu bar o restaurante sin caos en hojas de cálculo",
       subtitle:
         "Pedidos, cocina, catálogo y roles del equipo — una plataforma para operaciones de hospitality.",
+      badge: "Para bares y restaurantes",
+      imageAlt: "Interior cálido de restaurante con mesas e iluminación ambiental",
       ctaPrimary: "Crear cuenta gratis",
       ctaSecondary: "Ver cómo funciona",
+      mock: {
+        live: "En vivo",
+        ticketName: "Hamburguesa de la casa",
+        ticketMeta: "Mesa 4 · ×2",
+        ticketCooking: "Risotto",
+        ticketCookingMeta: "Mesa 7 · ×1",
+      },
+    },
+    showcase: {
+      dining: "Salón en movimiento",
+      kitchen: "Cocina al ritmo del servicio",
+      bar: "Bar y carta de bebidas",
     },
     problem: {
       title: "Salón, cocina y gestión en la misma página",
@@ -583,6 +597,11 @@ const es: MessageCatalog = {
     proof: {
       title: "Hecho para bares y restaurantes",
       body: "Stack open-source y multi-tenant, diseñado para servicio real.",
+      stats: {
+        realtime: {value: "Tiempo real", label: "Cola de cocina vía WebSocket"},
+        multitenant: {value: "Multi-tenant", label: "Una cuenta, varios locales"},
+        opensource: {value: "Open source", label: "Rails + Next.js, stack abierta"},
+      },
     },
     cta: {
       title: "¿Listo para simplificar el servicio?",

--- a/src/app/_lib/i18n/messages/fr.ts
+++ b/src/app/_lib/i18n/messages/fr.ts
@@ -190,8 +190,22 @@ const fr: MessageCatalog = {
       title: "Gérez votre bar ou restaurant sans chaos",
       subtitle:
         "Commandes, file cuisine, catalogue et rôles — une plateforme pour l'hospitality multi-sites.",
+      badge: "Pour bars et restaurants",
+      imageAlt: "Intérieur chaleureux de restaurant avec tables et éclairage ambiant",
       ctaPrimary: "Créer un compte gratuit",
       ctaSecondary: "Voir comment ça marche",
+      mock: {
+        live: "En direct",
+        ticketName: "Burger maison",
+        ticketMeta: "Table 4 · ×2",
+        ticketCooking: "Risotto",
+        ticketCookingMeta: "Table 7 · ×1",
+      },
+    },
+    showcase: {
+      dining: "Salle en mouvement",
+      kitchen: "Cuisine au rythme du service",
+      bar: "Bar et carte des boissons",
     },
     problem: {
       title: "Salle, cuisine et gestion sur la même page",
@@ -220,6 +234,11 @@ const fr: MessageCatalog = {
     proof: {
       title: "Conçu pour bars et restaurants",
       body: "Stack open-source et multi-tenant, pensé pour le service réel.",
+      stats: {
+        realtime: {value: "Temps réel", label: "File cuisine via WebSocket"},
+        multitenant: {value: "Multi-tenant", label: "Un compte, plusieurs établissements"},
+        opensource: {value: "Open source", label: "Rails + Next.js, stack ouverte"},
+      },
     },
     cta: {
       title: "Prêt à simplifier le service ?",

--- a/src/app/_lib/i18n/messages/pt-BR.ts
+++ b/src/app/_lib/i18n/messages/pt-BR.ts
@@ -556,8 +556,22 @@ const ptBR: MessageCatalog = {
       title: "Gerencie seu bar ou restaurante sem planilha caótica",
       subtitle:
         "Pedidos, fila da cozinha, cardápio e papéis da equipe — uma plataforma feita para operações de hospitality multi-unidade.",
+      badge: "Para bares e restaurantes",
+      imageAlt: "Ambiente acolhedor de restaurante com mesas e iluminação quente",
       ctaPrimary: "Criar conta grátis",
       ctaSecondary: "Ver como funciona",
+      mock: {
+        live: "Ao vivo",
+        ticketName: "Burger da casa",
+        ticketMeta: "Mesa 4 · ×2",
+        ticketCooking: "Risoto",
+        ticketCookingMeta: "Mesa 7 · ×1",
+      },
+    },
+    showcase: {
+      dining: "Salão em movimento",
+      kitchen: "Cozinha no ritmo do serviço",
+      bar: "Bar e carta de bebidas",
     },
     problem: {
       title: "Salão, cozinha e gestão na mesma página",
@@ -586,6 +600,11 @@ const ptBR: MessageCatalog = {
     proof: {
       title: "Feito para bares e restaurantes",
       body: "Stack open-source, multi-tenant de propósito, moldado por fluxos reais de serviço — não software genérico de varejo.",
+      stats: {
+        realtime: {value: "Tempo real", label: "Fila da cozinha via WebSocket"},
+        multitenant: {value: "Multi-tenant", label: "Uma conta, vários estabelecimentos"},
+        opensource: {value: "Open source", label: "Rails + Next.js, stack aberta"},
+      },
     },
     cta: {
       title: "Pronto para simplificar o serviço?",

--- a/src/app/_lib/i18n/messages/types.ts
+++ b/src/app/_lib/i18n/messages/types.ts
@@ -526,8 +526,22 @@ export type MessageCatalog = {
     hero: {
       title: string;
       subtitle: string;
+      badge: string;
+      imageAlt: string;
       ctaPrimary: string;
       ctaSecondary: string;
+      mock: {
+        live: string;
+        ticketName: string;
+        ticketMeta: string;
+        ticketCooking: string;
+        ticketCookingMeta: string;
+      };
+    };
+    showcase: {
+      dining: string;
+      kitchen: string;
+      bar: string;
     };
     problem: {
       title: string;
@@ -543,6 +557,11 @@ export type MessageCatalog = {
     proof: {
       title: string;
       body: string;
+      stats: {
+        realtime: {value: string; label: string};
+        multitenant: {value: string; label: string};
+        opensource: {value: string; label: string};
+      };
     };
     cta: {
       title: string;

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -3,6 +3,7 @@
 import {FormEvent, useState} from "react";
 import {useRouter} from "next/navigation";
 import {AuthFooterLink, AuthShell} from "@/app/_components/AuthShell";
+import {BRAND_CTA} from "@/app/_components/marketing/brand-styles";
 import {Buttons, Input} from "@/app/_components";
 import {useTranslations} from "@/app/_hooks/useTranslations";
 import {useAppDispatch} from "@/app/_store/hooks";
@@ -59,7 +60,7 @@ export default function ForgotPasswordPage() {
           <p className="text-sm text-red-600 bg-red-50 border border-red-100 rounded-lg px-3 py-2">{error}</p>
         )}
 
-        <Buttons type="submit" className="w-full rounded-xl" disabled={loading}>
+        <Buttons type="submit" className={`w-full rounded-xl ${BRAND_CTA}`} disabled={loading}>
           {loading ? t("auth.sending") : t("auth.sendCode")}
         </Buttons>
       </form>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,6 +3,8 @@
 import {FormEvent, useState} from "react";
 import Link from "next/link";
 import {useRouter} from "next/navigation";
+import {AuthShell} from "@/app/_components/AuthShell";
+import {BRAND_CTA} from "@/app/_components/marketing/brand-styles";
 import {Buttons, Input} from "@/app/_components";
 import {useTranslations} from "@/app/_hooks/useTranslations";
 import {useAppDispatch, useAppSelector} from "@/app/_store/hooks";
@@ -28,71 +30,67 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100 p-6">
-      <form
-        onSubmit={onSubmit}
-        className="w-full max-w-md bg-white rounded-2xl shadow-lg p-8 space-y-6"
-      >
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900">{t("auth.signInTitle")}</h1>
-          <p className="text-sm text-gray-500 mt-1">{t("auth.signInSubtitle")}</p>
-        </div>
-
-        <div className="space-y-4">
-          <div>
-            <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
-              {t("auth.email")}
-            </label>
-            <Input
-              id="email"
-              type="email"
-              name="email"
-              required
-              autoFocus
-              placeholder="you@example.com"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-            />
-          </div>
-
-          <div>
-            <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
-              {t("auth.password")}
-            </label>
-            <Input
-              id="password"
-              type="password"
-              name="password"
-              required
-              placeholder="••••••••"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-            />
-          </div>
-        </div>
-
-        {error && (
-          <p className="text-sm text-red-600 bg-red-50 border border-red-100 rounded-lg px-3 py-2">
-            {error}
+    <AuthShell
+      title={t("auth.signInTitle")}
+      subtitle={t("auth.signInSubtitle")}
+      footer={
+        <div className="space-y-2 text-center text-sm">
+          <p>
+            <Link href="/forgot-password" className="font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400">
+              {t("auth.forgotPassword")}
+            </Link>
           </p>
-        )}
-
-        <Buttons type="submit" className="w-full rounded-xl" disabled={status === "loading"}>
-          {status === "loading" ? t("auth.signingIn") : t("auth.signIn")}
-        </Buttons>
-
-        <div className="flex flex-col gap-2 text-center text-sm">
-          <Link href="/forgot-password" className="text-blue-600 hover:text-blue-700 font-medium">
-            {t("auth.forgotPassword")}
-          </Link>
-          <p className="text-gray-600">
+          <p className="text-muted">
             {t("auth.noAccount")}{" "}
-            <Link href="/signup" className="text-blue-600 hover:text-blue-700 font-medium">
+            <Link href="/signup" className="font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400">
               {t("auth.createOne")}
             </Link>
           </p>
         </div>
+      }
+    >
+      <form onSubmit={onSubmit} className="space-y-4">
+        <div>
+          <label htmlFor="email" className="mb-1 block text-sm font-medium text-foreground">
+            {t("auth.email")}
+          </label>
+          <Input
+            id="email"
+            type="email"
+            name="email"
+            required
+            autoFocus
+            placeholder="you@example.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </div>
+
+        <div>
+          <label htmlFor="password" className="mb-1 block text-sm font-medium text-foreground">
+            {t("auth.password")}
+          </label>
+          <Input
+            id="password"
+            type="password"
+            name="password"
+            required
+            placeholder="••••••••"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </div>
+
+        {error && (
+          <p className="rounded-lg border border-red-100 bg-red-50 px-3 py-2 text-sm text-red-600 dark:border-red-900/40 dark:bg-red-950/40 dark:text-red-300">
+            {error}
+          </p>
+        )}
+
+        <Buttons type="submit" className={`w-full rounded-xl ${BRAND_CTA}`} disabled={status === "loading"}>
+          {status === "loading" ? t("auth.signingIn") : t("auth.signIn")}
+        </Buttons>
       </form>
-    </div>
+    </AuthShell>
   );
 }

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -3,8 +3,8 @@
 import {FormEvent, Suspense, useState} from "react";
 import {useRouter, useSearchParams} from "next/navigation";
 import {AuthFooterLink, AuthShell} from "@/app/_components/AuthShell";
-import {Buttons, Input} from "@/app/_components";
-import {Loading} from "@/app/_components";
+import {AMBIENT_PAGE, BRAND_CTA} from "@/app/_components/marketing/brand-styles";
+import {Buttons, Input, Loading} from "@/app/_components";
 import {useTranslations} from "@/app/_hooks/useTranslations";
 import {useAppDispatch} from "@/app/_store/hooks";
 import {resetPassword, validateResetCode} from "@/app/_store/features/auth/authThunks";
@@ -90,7 +90,7 @@ function ResetPasswordForm() {
           <p className="text-sm text-red-600 bg-red-50 border border-red-100 rounded-lg px-3 py-2">{error}</p>
         )}
 
-        <Buttons type="submit" className="w-full rounded-xl" disabled={loading}>
+        <Buttons type="submit" className={`w-full rounded-xl ${BRAND_CTA}`} disabled={loading}>
           {loading ? t("auth.updating") : t("auth.updatePassword")}
         </Buttons>
       </form>
@@ -100,7 +100,7 @@ function ResetPasswordForm() {
 
 export default function ResetPasswordPage() {
   return (
-    <Suspense fallback={<div className="min-h-screen flex items-center justify-center"><Loading/></div>}>
+    <Suspense fallback={<div className={`flex min-h-screen items-center justify-center ${AMBIENT_PAGE}`}><Loading/></div>}>
       <ResetPasswordForm/>
     </Suspense>
   );

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -4,6 +4,7 @@ import {FormEvent, useState} from "react";
 import Link from "next/link";
 import {useRouter} from "next/navigation";
 import {AuthFooterLink, AuthShell} from "@/app/_components/AuthShell";
+import {BRAND_CTA} from "@/app/_components/marketing/brand-styles";
 import {Buttons, Input} from "@/app/_components";
 import {useTranslations} from "@/app/_hooks/useTranslations";
 import {useAppDispatch, useAppSelector} from "@/app/_store/hooks";
@@ -109,7 +110,7 @@ export default function SignUpPage() {
           </p>
         )}
 
-        <Buttons type="submit" className="w-full rounded-xl" disabled={status === "loading"}>
+        <Buttons type="submit" className={`w-full rounded-xl ${BRAND_CTA}`} disabled={status === "loading"}>
           {status === "loading" ? t("auth.creatingAccount") : t("auth.createAccount")}
         </Buttons>
 


### PR DESCRIPTION
## Summary
- Landing page visual refresh: warm gradients, Unsplash showcase photos, colored feature cards, stats row, and logo mark.
- Shared `brand-styles` applied to auth (`AuthShell` split layout with photo panel), legal pages, and logged-in app shell (`SidebarLayout`).
- Login migrated to `AuthShell`; all auth CTAs use brand blue. Plan 14 marked **completed**.

## Test plan
- [x] `npm run lint`
- [x] `npm test`
- [x] `NEXT_PUBLIC_API_URL=http://localhost:3000 npm run build`
- [x] `bin/plans_drift_check`
- [x] Manual: `/` logged out — hero, gallery, features, stats
- [x] Manual: `/login`, `/signup` — split layout + gradient on desktop
- [x] Manual: logged in — sidebar logo, ambient background
- [x] Manual: showcase bar image loads (fixed 404 URL)

Plan: [14-landing-page.md](docs/plans/14-landing-page.md)

Made with [Cursor](https://cursor.com)