### PR TITLE
feat(multi-tenant): complete plan 01 — platform routes and tenant guards

### DIFF
--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -20,9 +20,12 @@ Real-time kitchen: `useKitchenCable` → AnyCable WebSocket (`CABLE_URL`).
 
 ## Multi-tenant UX
 
+- **Tenant source of truth:** JWT user org from API (`auth.user.organization`) — never send `organization_id` on org-scoped creates/updates
 - `requiresOrganization()` + `hasOrganization()` in `AuthGuard` → redirect `/forbidden`
+- Super admin: platform console at `/platform` and `/platform/organizations`; blocked from `/orders`, `/kitchen`, `/tables`, `/inventory`
 - Super admin: read-only catalog mutations blocked via `canMutateOperationalData()` and route guards
 - Kitchen-only users: restricted to `/kitchen` and `/settings`
+- Kitchen cable: subscribes to `KitchenChannel` only — server scopes stream by session org
 
 ## Appearance
 

--- a/docs/context/auth-and-roles.md
+++ b/docs/context/auth-and-roles.md
@@ -21,19 +21,25 @@ Client-side route and action guards. **Not a security boundary** — API CanCan 
 | `canAccessKitchen` | KITCHEN, ADMIN, WAITER, CASH_REGISTER |
 | `isKitchenStaff` | KITCHEN — restricted to `/kitchen`, `/settings` |
 | `canMutateOperationalData` | All except SUPER_ADMIN |
-| `canAccessOrganizations` | ADMIN (own org), SUPER_ADMIN (cross-org list) |
+| `canAccessOrganizations` | ADMIN (own org), SUPER_ADMIN (cross-org via `/platform/organizations`) |
+| `canAccessPlatformRoutes` | SUPER_ADMIN (`/platform/*`) |
+| `canAccessOrgOperationalRoutes` | All except SUPER_ADMIN (`/orders`, `/kitchen`, `/tables`, `/inventory`) |
 | `requiresOrganization` + `hasOrganization` | Org-scoped roles without org → `/forbidden` |
 
 ## AuthGuard redirect rules
 
 1. Unauthenticated → `/login`
 2. Org-scoped role without org → `/forbidden`
-3. Super admin on operational create/edit paths → list page for that resource
-4. Kitchen staff off allowed paths → `/kitchen`
-5. Non-admin on `/users` → `/`
-6. Non inventory role on `/inventory` → `/`
-7. Non org-access on `/organizations` → `/`
-8. Non dashboard role on `/` → `/orders` (super admin may view dashboard)
+3. Non–super admin on `/platform/*` → `/`
+4. Super admin on org operational paths (`/orders`, `/kitchen`, `/tables`, `/inventory`) → `/platform`
+5. Super admin on operational create/edit paths → list page for that resource
+6. Kitchen staff off allowed paths → `/kitchen`
+7. Non-admin on `/users` → `/`
+8. Non inventory role on `/inventory` → `/`
+9. Non org-access on `/organizations` → `/`
+10. Non dashboard role on `/` → `/orders` (super admin may view dashboard)
+
+**Tenant isolation:** API enforces org scope via JWT; client 403 → `/forbidden`. MSW coverage in `tenant-isolation.integration.test.ts`.
 
 Public/marketing routes: `isMarketingShellPath()` in `_lib/auth-routes.ts` — skip guard.
 

--- a/docs/plans/01-multi-tenant.md
+++ b/docs/plans/01-multi-tenant.md
@@ -1,11 +1,14 @@
 # Plan: Multi-tenant (frontend)
 
-**Status:** in progress (Phases 1–2 done; Phases 3–4 pending)  
+**Status:** completed  
 **Project:** ubuteco-react  
 **Backend:** [01-multi-tenant.md](../../../ubuteco_api/docs/plans/01-multi-tenant.md)  
-**Priority:** P0 (after / in parallel with API Phase 1–2)
+**Priority:** P0  
+**Branch:** merged via `feature/multi-tenant-complete`
 
 **Tenant model (approved):** shared DB schema + `organization_id` on the API; front does not send tenant id in bodies. Schema-per-tenant is **not** planned — see backend [Architecture decision](../../../ubuteco_api/docs/plans/01-multi-tenant.md#architecture-decision-approved).
+
+**Tenant source of truth:** JWT session user → `auth.user.organization` from API responses. Client never sends `organization_id` on org-scoped creates/updates.
 
 ---
 
@@ -30,21 +33,32 @@ Frontend must not rely on sending `organization_id` for scoped operations; use t
 
 ---
 
-## Phase 3 — Super admin (future)
+## Phase 3 — Super admin
 
-- [ ] When platform API exists, separate `/platform/*` routes or admin-only section
-- [ ] Do not reuse org-scoped order/kitchen pages for cross-org browsing without org switcher
+- [x] Platform routes: `/platform` (home), `/platform/organizations` (cross-org list)
+- [x] Super admin blocked from org operational routes (`/orders`, `/kitchen`, `/tables`, `/inventory`) → `/platform`
+- [x] Org admin `/organizations` unchanged; super admin redirected to platform list
 
 ---
 
 ## Phase 4 — Tests
 
-- [ ] MSW/fixtures: user org A cannot request org B resource ids (expect 403 from API)
-- [ ] Kitchen cable: subscription uses same session org only
+- [x] MSW: cross-tenant order GET → 403 → `/forbidden`; create order without `organization_id`
+- [x] Kitchen cable: `KitchenChannel` subscription without tenant params (server scopes by JWT org)
+- [x] `auth-roles.test.ts`: platform + org operational path guards
 
 ---
 
 ## Definition of done
 
-- [ ] No client sends `organization_id` on create/update except explicit super-admin flows (when built)
-- [ ] Documented in `docs/plans` and team knows tenant source of truth is JWT user org
+- [x] No client sends `organization_id` on create/update except explicit super-admin flows (platform org API only)
+- [x] Documented in `docs/plans`, `docs/context/auth-and-roles.md`, and `docs/context/architecture.md`
+
+---
+
+## References
+
+- `src/app/_lib/auth-roles.ts`, `src/app/_components/AuthGuard.tsx`
+- `src/app/platform/page.tsx`, `src/app/platform/organizations/page.tsx`
+- `src/app/_services/tenant-isolation.integration.test.ts`
+- `src/app/_hooks/useKitchenCable.ts`

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -31,7 +31,7 @@ Ordered by priority. **#3 is deferred to the end** (see note above).
 
 | # | Plan | Status | Priority | Backend doc |
 |---|------|--------|----------|-------------|
-| 1 | [Multi-tenant](./01-multi-tenant.md) | in progress | P0 | [API](../../../ubuteco_api/docs/plans/01-multi-tenant.md) |
+| 1 | [Multi-tenant](./01-multi-tenant.md) | completed | P0 | [API](../../../ubuteco_api/docs/plans/01-multi-tenant.md) |
 | 7 | [Users admin UI](./07-users-ui.md) | completed | P1 | [10-users-admin-api](../../../ubuteco_api/docs/plans/10-users-admin-api.md) |
 | 8 | [Settings — account deletion](./08-settings-account-deletion.md) | completed | P1 | [10-users-admin-api](../../../ubuteco_api/docs/plans/10-users-admin-api.md) |
 | 6 | [Organizations UI](./06-organizations-ui.md) | completed | P1 | Organizations API + [02](../../../ubuteco_api/docs/plans/02-locale-and-currency.md) |
@@ -57,7 +57,7 @@ Ordered by priority. **#3 is deferred to the end** (see note above).
 | [02 Locale & currency](./02-locale-and-currency.md) | [#27](https://github.com/Sartori-RIA/ubuteco-react/pull/27) | `es`, `fr`, `fr-CA`, `en-CA`; CAD + LATAM pesos; Brazil/Canada/EU timezones; order status UX |
 | [10 Browser document titles](./10-document-titles.md) | [#31](https://github.com/Sartori-RIA/ubuteco-react/pull/31) | `useDocumentTitle`, `page-titles`, entity titles on detail/edit routes |
 
-**In progress:** [01 Multi-tenant](./01-multi-tenant.md) (Phases 3–4), [14 Marketing landing page](./14-landing-page.md) (PR [#34](https://github.com/Sartori-RIA/ubuteco-react/pull/34)).
+**In progress:** [14 Marketing landing page](./14-landing-page.md) (PR [#34](https://github.com/Sartori-RIA/ubuteco-react/pull/34)).
 
 **Next up:** [15 Product expiry alerts](./15-product-expiry-alerts.md). **Last:** [03 Subscription plans](./03-subscription-plans.md).
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -51,6 +51,7 @@ Ordered by priority. **#3 is deferred to the end** (see note above).
 
 | Plan | PR | Notes |
 |------|-----|-------|
+| [01 Multi-tenant](./01-multi-tenant.md) | [#35](https://github.com/Sartori-RIA/ubuteco-react/pull/35) | Platform routes, super-admin guards, tenant isolation tests |
 | [09 Frontend performance](./09-frontend-performance.md) | [#33](https://github.com/Sartori-RIA/ubuteco-react/pull/33) | Auth fetch dedup, orders list cache, kitchen memo |
 | [08 Settings — account deletion](./08-settings-account-deletion.md) | [#28](https://github.com/Sartori-RIA/ubuteco-react/pull/28) | Danger zone only for org admin; staff/super-admin guidance |
 | [11 Inventory UI](./11-inventory-ui.md) | [#26](https://github.com/Sartori-RIA/ubuteco-react/pull/26) | Stock display, adjust panel, `/inventory`, i18n follow-ups |

--- a/src/app/_components/AuthGuard.tsx
+++ b/src/app/_components/AuthGuard.tsx
@@ -8,6 +8,8 @@ import {
   canAccessDashboard,
   canAccessInventory,
   canAccessOrganizations,
+  canAccessOrgOperationalRoutes,
+  canAccessPlatformRoutes,
   canManageUsers,
   hasOrganization,
   isAdminOnlyPath,
@@ -17,6 +19,8 @@ import {
   isKitchenStaff,
   isOperationalMutationPath,
   isOrganizationPath,
+  isOrgOperationalPath,
+  isPlatformPath,
   isSuperAdmin,
   requiresOrganization,
 } from "@/app/_lib/auth-roles";
@@ -51,6 +55,16 @@ export default function AuthGuard({children}: {children: ReactNode}) {
 
     if (user && requiresOrganization(user) && !hasOrganization(user)) {
       router.replace("/forbidden");
+      return;
+    }
+
+    if (user && isPlatformPath(pathname) && !canAccessPlatformRoutes(user)) {
+      router.replace("/");
+      return;
+    }
+
+    if (user && isOrgOperationalPath(pathname) && !canAccessOrgOperationalRoutes(user)) {
+      router.replace("/platform");
       return;
     }
 

--- a/src/app/_hooks/useKitchenCable.test.ts
+++ b/src/app/_hooks/useKitchenCable.test.ts
@@ -1,0 +1,12 @@
+import {describe, expect, it} from "vitest";
+import {
+  kitchenCableSubscriptionParams,
+  KITCHEN_CABLE_CHANNEL,
+} from "@/app/_hooks/useKitchenCable";
+
+describe("kitchenCableSubscriptionParams", () => {
+  it("subscribes only to KitchenChannel without tenant params", () => {
+    expect(kitchenCableSubscriptionParams()).toEqual({channel: KITCHEN_CABLE_CHANNEL});
+    expect(kitchenCableSubscriptionParams()).not.toHaveProperty("organization_id");
+  });
+});

--- a/src/app/_hooks/useKitchenCable.ts
+++ b/src/app/_hooks/useKitchenCable.ts
@@ -9,6 +9,17 @@ import {useAppDispatch} from "@/app/_store/hooks";
 import {setCableConnected, ticketReceived} from "@/app/_store/features/kitchen/kitchenSlice";
 import {applyKitchenCableMessage} from "@/app/kitchen/_lib/apply-kitchen-cable-message";
 
+/** Server scopes stream by JWT organization — client must not pass tenant id. */
+export const KITCHEN_CABLE_CHANNEL = "KitchenChannel";
+
+export type KitchenCableSubscriptionParams = {
+  channel: typeof KITCHEN_CABLE_CHANNEL;
+};
+
+export function kitchenCableSubscriptionParams(): KitchenCableSubscriptionParams {
+  return {channel: KITCHEN_CABLE_CHANNEL};
+}
+
 function patchSubscriptionNotify(consumer: Consumer) {
   const subscriptions = consumer.subscriptions as {
     notify: (identifier: string, callbackName: string, ...args: unknown[]) => void;
@@ -61,7 +72,7 @@ export function useKitchenCable(enabled: boolean, options: Options = {}) {
       consumer = createConsumer(url);
       patchSubscriptionNotify(consumer);
 
-      subscription = consumer.subscriptions.create({channel: "KitchenChannel"}, {
+      subscription = consumer.subscriptions.create(kitchenCableSubscriptionParams(), {
         connected() {
           console.info("[KitchenCable] subscription connected");
           dispatch(setCableConnected(true));

--- a/src/app/_lib/auth-roles.test.ts
+++ b/src/app/_lib/auth-roles.test.ts
@@ -2,11 +2,15 @@ import {describe, expect, it} from "vitest";
 import {
   canAccessOrganizations,
   canAccessDashboard,
+  canAccessOrgOperationalRoutes,
+  canAccessPlatformRoutes,
   canDeleteOwnAccount,
   canManageOrganization,
   canManageUsers,
   isAdminOnlyPath,
+  isOrgOperationalPath,
   isOrganizationPath,
+  isPlatformPath,
 } from "@/app/_lib/auth-roles";
 import {User} from "@/app/_types";
 
@@ -70,5 +74,33 @@ describe("users admin access", () => {
     expect(isAdminOnlyPath("/users/new")).toBe(true);
     expect(isAdminOnlyPath("/users/42/edit")).toBe(true);
     expect(isAdminOnlyPath("/orders")).toBe(false);
+  });
+});
+
+describe("platform and org operational routes", () => {
+  it("matches platform paths", () => {
+    expect(isPlatformPath("/platform")).toBe(true);
+    expect(isPlatformPath("/platform/organizations")).toBe(true);
+    expect(isPlatformPath("/organizations")).toBe(false);
+  });
+
+  it("matches org operational paths", () => {
+    expect(isOrgOperationalPath("/orders")).toBe(true);
+    expect(isOrgOperationalPath("/orders/42")).toBe(true);
+    expect(isOrgOperationalPath("/kitchen")).toBe(true);
+    expect(isOrgOperationalPath("/tables")).toBe(true);
+    expect(isOrgOperationalPath("/inventory")).toBe(true);
+    expect(isOrgOperationalPath("/beers")).toBe(false);
+  });
+
+  it("restricts platform routes to super admin", () => {
+    expect(canAccessPlatformRoutes(userWithRole("SUPER_ADMIN"))).toBe(true);
+    expect(canAccessPlatformRoutes(userWithRole("ADMIN"))).toBe(false);
+  });
+
+  it("blocks super admin from org operational routes", () => {
+    expect(canAccessOrgOperationalRoutes(userWithRole("SUPER_ADMIN"))).toBe(false);
+    expect(canAccessOrgOperationalRoutes(userWithRole("ADMIN"))).toBe(true);
+    expect(canAccessOrgOperationalRoutes(userWithRole("WAITER"))).toBe(true);
   });
 });

--- a/src/app/_lib/auth-roles.ts
+++ b/src/app/_lib/auth-roles.ts
@@ -90,6 +90,30 @@ export function isOrganizationPath(pathname: string): boolean {
   return ORGANIZATION_PATH.test(pathname);
 }
 
+const PLATFORM_PATH = /^\/platform(\/|$)/;
+
+/** Super-admin platform console (`/platform`, `/platform/organizations`). */
+export function isPlatformPath(pathname: string): boolean {
+  return PLATFORM_PATH.test(pathname);
+}
+
+/** Org-scoped operational routes super admins must not use without a tenant context. */
+const ORG_OPERATIONAL_PATH =
+  /^\/(orders|kitchen|tables|inventory)(\/|$)/;
+
+export function isOrgOperationalPath(pathname: string): boolean {
+  return ORG_OPERATIONAL_PATH.test(pathname);
+}
+
+/** Super admin browses platform routes and read-only catalog — not live org operations. */
+export function canAccessOrgOperationalRoutes(user: User | null | undefined): boolean {
+  return !isSuperAdmin(user);
+}
+
+export function canAccessPlatformRoutes(user: User | null | undefined): boolean {
+  return isSuperAdmin(user);
+}
+
 /** Paths restricted to org admins (staff user management). */
 const ADMIN_ONLY_PATH = /^\/users(\/|$)/;
 

--- a/src/app/_lib/nav-config.ts
+++ b/src/app/_lib/nav-config.ts
@@ -78,6 +78,10 @@ export const NAV_GROUPS: NavGroup[] = [
 ];
 
 function isItemVisible(item: NavItem, user: User | null | undefined): boolean {
+  if (isSuperAdmin(user)) {
+    const blockedLinks = new Set(["/orders", "/kitchen", "/tables", "/inventory"]);
+    if (blockedLinks.has(item.link)) return false;
+  }
   if (item.superAdminOnly && !isSuperAdmin(user)) return false;
   if (item.adminOnly && !canManageUsers(user)) return false;
   if (item.organizationAccess && !canAccessOrganizations(user)) return false;

--- a/src/app/_services/tenant-isolation.integration.test.ts
+++ b/src/app/_services/tenant-isolation.integration.test.ts
@@ -1,0 +1,42 @@
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import {http, HttpResponse} from "msw";
+import {server} from "@/test/msw/server";
+import {apiUrl} from "@/test/msw/handlers";
+import {ordersService} from "@/app/_services/orders.service";
+
+vi.mock("@/app/_lib/auth-storage", () => ({
+  getAuthToken: () => "org-a-token",
+}));
+
+describe("tenant isolation (MSW)", () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_URL = "http://localhost:3000";
+    vi.stubGlobal("window", {location: {href: ""}});
+  });
+
+  it("redirects to forbidden when API returns 403 for another org order", async () => {
+    server.use(
+      http.get(apiUrl("v1/orders/999"), () => new HttpResponse(null, {status: 403}))
+    );
+
+    await ordersService.show(999);
+
+    expect(window.location.href).toBe("/forbidden");
+  });
+
+  it("creates an order without sending organization_id in the body", async () => {
+    let capturedBody: Record<string, unknown> | undefined;
+
+    server.use(
+      http.post(apiUrl("v1/orders"), async ({request}) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({id: 10, status: "open"});
+      })
+    );
+
+    await ordersService.create({table_id: 3});
+
+    expect(capturedBody).toEqual({table_id: 3});
+    expect(capturedBody).not.toHaveProperty("organization_id");
+  });
+});

--- a/src/app/dashboard/components/SuperAdminHome.tsx
+++ b/src/app/dashboard/components/SuperAdminHome.tsx
@@ -16,7 +16,7 @@ export function SuperAdminHome() {
       <Card title={t("dashboard.platform.organizationsTitle")} className="hover:translate-y-0">
         <p className="mb-4 text-sm text-muted">{t("dashboard.platform.organizationsHint")}</p>
         <Link
-          href="/organizations"
+          href="/platform/organizations"
           className="inline-flex rounded-xl border border-border bg-surface px-4 py-2 text-sm font-medium text-foreground hover:bg-surface-muted"
         >
           {t("dashboard.platform.openOrganizations")}

--- a/src/app/organizations/components/SuperAdminOrganizationsList.tsx
+++ b/src/app/organizations/components/SuperAdminOrganizationsList.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import {useEffect, useState} from "react";
+import {ApiMetaData, Organization} from "@/app/_types";
+import {Card, FormErrors, Loading, Toolbar} from "@/app/_components";
+import {Pagination} from "@/app/_components/Pagination";
+import {useTranslations} from "@/app/_hooks/useTranslations";
+import {platformOrganizationsService} from "@/app/_services/platform-organizations.service";
+import {ApiError} from "@/app/_services/api-fetch";
+import {OrganizationsTable} from "@/app/organizations/components/OrganizationsTable";
+
+export function SuperAdminOrganizationsList() {
+  const t = useTranslations();
+  const [organizations, setOrganizations] = useState<Organization[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [page, setPage] = useState(1);
+  const [meta, setMeta] = useState<ApiMetaData>({
+    count: 0,
+    last: 0,
+    page: 1,
+    pages: 1,
+    previous: null,
+  });
+  const [errors, setErrors] = useState<string[] | undefined>();
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setLoading(true);
+      setErrors(undefined);
+      void platformOrganizationsService
+        .fetchAll({search: searchTerm, page: 1})
+        .then((response) => {
+          setOrganizations(response.data);
+          setMeta(response.meta);
+          setPage(response.meta.page);
+        })
+        .catch((error) => {
+          if (error instanceof ApiError) {
+            setErrors(error.data);
+          } else {
+            setErrors([t("organizations.list.loadFailed")]);
+          }
+        })
+        .finally(() => setLoading(false));
+    }, 500);
+
+    return () => clearTimeout(timeout);
+  }, [searchTerm, t]);
+
+  const loadMore = () => {
+    const nextPage = page + 1;
+    setLoading(true);
+    void platformOrganizationsService
+      .fetchAll({search: searchTerm, page: nextPage})
+      .then((response) => {
+        setOrganizations((current) => [...current, ...response.data]);
+        setMeta(response.meta);
+        setPage(response.meta.page);
+      })
+      .catch((error) => {
+        if (error instanceof ApiError) {
+          setErrors(error.data);
+        }
+      })
+      .finally(() => setLoading(false));
+  };
+
+  return (
+    <div className="space-y-6">
+      <Toolbar
+        title={t("organizations.list.title")}
+        searchValue={searchTerm}
+        onSearch={(e) => setSearchTerm(e.target.value)}
+        showAdd={false}
+      />
+
+      <FormErrors errors={errors}/>
+
+      <Card title={t("organizations.list.cardTitle")} className="hover:translate-y-0">
+        {loading && organizations.length === 0 ? (
+          <Loading/>
+        ) : (
+          <OrganizationsTable organizations={organizations}/>
+        )}
+        <Pagination meta={meta} loading={loading} onLoadMore={loadMore}/>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/organizations/components/index.ts
+++ b/src/app/organizations/components/index.ts
@@ -2,3 +2,4 @@ export {OrganizationForm} from "./OrganizationForm";
 export {OrganizationOperationalToggle} from "./OrganizationOperationalToggle";
 export {OrganizationProfilePage} from "./OrganizationProfilePage";
 export {OrganizationsTable} from "./OrganizationsTable";
+export {SuperAdminOrganizationsList} from "./SuperAdminOrganizationsList";

--- a/src/app/organizations/page.tsx
+++ b/src/app/organizations/page.tsx
@@ -1,97 +1,12 @@
 "use client";
 
-import {useEffect, useState} from "react";
+import {useEffect} from "react";
 import dynamic from "next/dynamic";
 import {useRouter} from "next/navigation";
-import {ApiMetaData, Organization} from "@/app/_types";
-import {Card, FormErrors, Loading, Toolbar} from "@/app/_components";
-import {Pagination} from "@/app/_components/Pagination";
+import {Loading} from "@/app/_components";
 import {useAuthCapabilities} from "@/app/_hooks/useAuthCapabilities";
 import {canManageOrganization, isSuperAdmin} from "@/app/_lib/auth-roles";
-import {platformOrganizationsService} from "@/app/_services/platform-organizations.service";
-import {ApiError} from "@/app/_services/api-fetch";
-import {useTranslations} from "@/app/_hooks/useTranslations";
-import {OrganizationProfilePage, OrganizationsTable} from "@/app/organizations/components";
-
-function SuperAdminOrganizationsList() {
-  const t = useTranslations();
-  const [organizations, setOrganizations] = useState<Organization[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [searchTerm, setSearchTerm] = useState("");
-  const [page, setPage] = useState(1);
-  const [meta, setMeta] = useState<ApiMetaData>({
-    count: 0,
-    last: 0,
-    page: 1,
-    pages: 1,
-    previous: null,
-  });
-  const [errors, setErrors] = useState<string[] | undefined>();
-
-  useEffect(() => {
-    const timeout = setTimeout(() => {
-      setLoading(true);
-      setErrors(undefined);
-      void platformOrganizationsService
-        .fetchAll({search: searchTerm, page: 1})
-        .then((response) => {
-          setOrganizations(response.data);
-          setMeta(response.meta);
-          setPage(response.meta.page);
-        })
-        .catch((error) => {
-          if (error instanceof ApiError) {
-            setErrors(error.data);
-          } else {
-            setErrors([t("organizations.list.loadFailed")]);
-          }
-        })
-        .finally(() => setLoading(false));
-    }, 500);
-
-    return () => clearTimeout(timeout);
-  }, [searchTerm, t]);
-
-  const loadMore = () => {
-    const nextPage = page + 1;
-    setLoading(true);
-    void platformOrganizationsService
-      .fetchAll({search: searchTerm, page: nextPage})
-      .then((response) => {
-        setOrganizations((current) => [...current, ...response.data]);
-        setMeta(response.meta);
-        setPage(response.meta.page);
-      })
-      .catch((error) => {
-        if (error instanceof ApiError) {
-          setErrors(error.data);
-        }
-      })
-      .finally(() => setLoading(false));
-  };
-
-  return (
-    <div className="space-y-6">
-      <Toolbar
-        title={t("organizations.list.title")}
-        searchValue={searchTerm}
-        onSearch={(e) => setSearchTerm(e.target.value)}
-        showAdd={false}
-      />
-
-      <FormErrors errors={errors}/>
-
-      <Card title={t("organizations.list.cardTitle")} className="hover:translate-y-0">
-        {loading && organizations.length === 0 ? (
-          <Loading/>
-        ) : (
-          <OrganizationsTable organizations={organizations}/>
-        )}
-        <Pagination meta={meta} loading={loading} onLoadMore={loadMore}/>
-      </Card>
-    </div>
-  );
-}
+import {OrganizationProfilePage} from "@/app/organizations/components";
 
 function Page() {
   const router = useRouter();
@@ -101,17 +16,17 @@ function Page() {
 
   useEffect(() => {
     if (!user) return;
-    if (!isSuper && !isOrgAdmin) {
+    if (isSuper) {
+      router.replace("/platform/organizations");
+      return;
+    }
+    if (!isOrgAdmin) {
       router.replace("/");
     }
   }, [user, isSuper, isOrgAdmin, router]);
 
-  if (!user || (!isSuper && !isOrgAdmin)) {
+  if (!user || isSuper || !isOrgAdmin) {
     return <Loading/>;
-  }
-
-  if (isSuper) {
-    return <SuperAdminOrganizationsList/>;
   }
 
   if (!user.organization) {

--- a/src/app/platform/organizations/page.tsx
+++ b/src/app/platform/organizations/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import {useEffect} from "react";
+import {useRouter} from "next/navigation";
+import {Loading} from "@/app/_components";
+import {SuperAdminOrganizationsList} from "@/app/organizations/components/SuperAdminOrganizationsList";
+import {useAuthCapabilities} from "@/app/_hooks/useAuthCapabilities";
+import {canAccessPlatformRoutes} from "@/app/_lib/auth-roles";
+
+function PlatformOrganizationsPage() {
+  const router = useRouter();
+  const {user} = useAuthCapabilities();
+
+  useEffect(() => {
+    if (!user) return;
+    if (!canAccessPlatformRoutes(user)) {
+      router.replace("/");
+    }
+  }, [user, router]);
+
+  if (!user || !canAccessPlatformRoutes(user)) {
+    return <Loading/>;
+  }
+
+  return <SuperAdminOrganizationsList/>;
+}
+
+export default dynamic(() => Promise.resolve(PlatformOrganizationsPage), {ssr: false});

--- a/src/app/platform/page.tsx
+++ b/src/app/platform/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import {useEffect} from "react";
+import {useRouter} from "next/navigation";
+import {Loading} from "@/app/_components";
+import {SuperAdminHome} from "@/app/dashboard/components/SuperAdminHome";
+import {useAuthCapabilities} from "@/app/_hooks/useAuthCapabilities";
+import {canAccessPlatformRoutes} from "@/app/_lib/auth-roles";
+
+function PlatformHomePage() {
+  const router = useRouter();
+  const {user} = useAuthCapabilities();
+
+  useEffect(() => {
+    if (!user) return;
+    if (!canAccessPlatformRoutes(user)) {
+      router.replace("/");
+    }
+  }, [user, router]);
+
+  if (!user || !canAccessPlatformRoutes(user)) {
+    return <Loading/>;
+  }
+
+  return <SuperAdminHome/>;
+}
+
+export default dynamic(() => Promise.resolve(PlatformHomePage), {ssr: false});


### PR DESCRIPTION
## Summary
- Add super-admin platform routes: `/platform` and `/platform/organizations`.
- Block super admin from org operational pages (`/orders`, `/kitchen`, `/tables`, `/inventory`) via `AuthGuard` and sidebar nav.
- Redirect super admin `/organizations` → `/platform/organizations`; org admin flow unchanged.
- Kitchen cable: explicit `KitchenChannel` subscription params (no tenant id on client).
- Tests: tenant isolation MSW (403 → `/forbidden`, no `organization_id` on order create), platform path guards, cable channel.
- Plan 01 + README + context docs marked **completed**.

## Test plan
- [x] `npm run lint`
- [x] `npm test` (98)
- [x] `NEXT_PUBLIC_API_URL=http://localhost:3000 npm run build`
- [x] `bin/plans_drift_check`
- [ ] Manual: login as SUPER_ADMIN — `/orders` redirects to `/platform`; `/platform/organizations` lists tenants
- [ ] Manual: login as ADMIN — `/organizations` shows own org; `/platform` redirects to `/`

Plan: [01-multi-tenant.md](docs/plans/01-multi-tenant.md)

Made with [Cursor](https://cursor.com)